### PR TITLE
method for obtaining the roles/user from aws-auth configmap is added

### DIFF
--- a/cloudsupport/v1/ekssupport.go
+++ b/cloudsupport/v1/ekssupport.go
@@ -147,12 +147,22 @@ func (EKSSupport *EKSSupport) GetEKSCfgMap(kapi *k8sinterface.KubernetesApi, nam
 		return nil, err
 	}
 
-	if err := json.Unmarshal([]byte(eksCfgMap.Data["mapRoles"]), &authData.MapRoles); err != nil {
-		return nil, err
+	if mapRoles, ok := eksCfgMap.Data["mapRoles"]; ok {
+
+		if err := json.Unmarshal([]byte(mapRoles), &authData.MapRoles); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("'mapRoles' is missing from the EKS config object")
 	}
 
-	if err := json.Unmarshal([]byte(eksCfgMap.Data["mapUsers"]), &authData.MapUsers); err != nil {
-		return nil, err
+	if mapUsers, ok := eksCfgMap.Data["mapUsers"]; ok {
+
+		if err := json.Unmarshal([]byte(mapUsers), &authData.MapUsers); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("'mapUsers' is missing from the EKS config object")
 	}
 
 	return eksCfgMap, nil


### PR DESCRIPTION

This is related to the issue no. #670 on the kubescape repo. I have added a method for obtaining the roles/user from aws-auth configmap 