### PR TITLE
function for getting groupid's from rolebindings is added

### DIFF
--- a/cloudsupport/v1/akssupport.go
+++ b/cloudsupport/v1/akssupport.go
@@ -127,7 +127,7 @@ func (AKSSupport *AKSSupport) GetGroupIdsRoleBindings(kapi *k8sinterface.Kuberne
 		clusterrolebindings, err := kapi.KubernetesClient.RbacV1().ClusterRoleBindings().List(context.Background(), metav1.ListOptions{})
 
 		if err != nil {
-			return nil, fmt.Errorf("No clusterrolebindings are found inside the cluster")
+			return nil, fmt.Errorf("no clusterrolebindings are found inside the cluster")
 		}
 		for _, rolebinding := range clusterrolebindings.Items {
 			for _, subjects := range rolebinding.Subjects {
@@ -143,7 +143,7 @@ func (AKSSupport *AKSSupport) GetGroupIdsRoleBindings(kapi *k8sinterface.Kuberne
 	rolebindings, err := kapi.KubernetesClient.RbacV1().RoleBindings(namespace).List(context.Background(), metav1.ListOptions{})
 
 	if err != nil {
-		return nil, fmt.Errorf("No rolebindings are found in the %s namespace ", namespace)
+		return nil, fmt.Errorf("no rolebindings are found in the %s namespace ", namespace)
 	}
 
 	for _, rolebinding := range rolebindings.Items {

--- a/cloudsupport/v1/akssupportmock.go
+++ b/cloudsupport/v1/akssupportmock.go
@@ -39,5 +39,5 @@ func (AKSSupportM *AKSSupportMock) GetResourceGroup() (string, error) {
 }
 
 func (AKSSupportM *AKSSupportMock) GetGroupIdsRoleBindings(kapi *k8sinterface.KubernetesApi, namespace string) ([]string, error) {
-	return ["e808215d-d159-49ba-8bb6-9661ba478842"], nil
+	return []string{"e808215d-d159-49ba-8bb6-9661ba478842", "unexpected comma, expecting type"}, nil
 }

--- a/cloudsupport/v1/akssupportmock.go
+++ b/cloudsupport/v1/akssupportmock.go
@@ -6,6 +6,7 @@ import (
 	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v2"
 	"github.com/kubescape/k8s-interface/cloudsupport/mockobjects"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 )
 
 func NewAKSSupportMock() *AKSSupportMock {
@@ -35,4 +36,8 @@ func (AKSSupportM *AKSSupportMock) GetSubscriptionID() (string, error) {
 
 func (AKSSupportM *AKSSupportMock) GetResourceGroup() (string, error) {
 	return "armo-dev", nil
+}
+
+func (AKSSupportM *AKSSupportMock) GetGroupIdsRoleBindings(kapi *k8sinterface.KubernetesApi, namespace string) ([]string, error) {
+	return ["e808215d-d159-49ba-8bb6-9661ba478842"], nil
 }


### PR DESCRIPTION
Hi @dwertent , 

Related to : Enrich RoleBinding/ClusterRoleBinding objects with cloud vendor infromation #670
for Azure AKS Cluster

I've added support for getting groupIds/ UPN for single azure users from the rolebindings/clusterrolesbindings.
kindly Review.

