### PR TITLE
Add  GetPodStatus and update ListPods

### DIFF
--- a/k8sinterface/k8sstatic.go
+++ b/k8sinterface/k8sstatic.go
@@ -32,7 +32,7 @@ func SetLabel(labels map[string]string, key string, val bool) {
 	labels[key] = boolutils.BoolToString(val)
 }
 
-func (k8sAPI *KubernetesApi) ListPods(namespace string, podLabels map[string]string) ([]corev1.Pod, error) {
+func (k8sAPI *KubernetesApi) ListPods(namespace string, podLabels map[string]string) (*corev1.PodList, error) {
 	listOptions := metav1.ListOptions{}
 	if len(podLabels) > 0 {
 		set := labels.Set(podLabels)
@@ -40,7 +40,7 @@ func (k8sAPI *KubernetesApi) ListPods(namespace string, podLabels map[string]str
 	}
 	pods, err := k8sAPI.KubernetesClient.CoreV1().Pods(namespace).List(context.Background(), listOptions)
 	if err != nil {
-		return []corev1.Pod{}, err
+		return nil, err
 	}
-	return pods.Items, nil
+	return pods, nil
 }

--- a/workloadinterface/interface.go
+++ b/workloadinterface/interface.go
@@ -69,6 +69,7 @@ type IBasicWorkload interface {
 	GetConfigMapsOfContainer() (map[string][]string, error)
 	GetSecrets() ([]string, error)
 	GetConfigMaps() ([]string, error)
+	GetPodStatus() (*corev1.PodStatus, error)
 	//GetSpiffe() string
 
 	// REMOVE

--- a/workloadinterface/testdata/workloadmethods/podstatusnotpresent.json
+++ b/workloadinterface/testdata/workloadmethods/podstatusnotpresent.json
@@ -1,0 +1,105 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx:1.15\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}\n"
+        },
+        "creationTimestamp": "2023-02-02T12:49:54Z",
+        "name": "nginx",
+        "namespace": "default",
+        "resourceVersion": "64138",
+        "uid": "c67b47c0-d12e-4505-ae90-f24f2125bec6"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "nginx:1.15",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "nginx",
+                "ports": [
+                    {
+                        "containerPort": 80,
+                        "protocol": "TCP"
+                    }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "kube-api-access-2k5s7",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "enableServiceLinks": true,
+        "nodeName": "minikube",
+        "preemptionPolicy": "PreemptLowerPriority",
+        "priority": 0,
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/not-ready",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            },
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/unreachable",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            }
+        ],
+        "volumes": [
+            {
+                "name": "kube-api-access-2k5s7",
+                "projected": {
+                    "defaultMode": 420,
+                    "sources": [
+                        {
+                            "serviceAccountToken": {
+                                "expirationSeconds": 3607,
+                                "path": "token"
+                            }
+                        },
+                        {
+                            "configMap": {
+                                "items": [
+                                    {
+                                        "key": "ca.crt",
+                                        "path": "ca.crt"
+                                    }
+                                ],
+                                "name": "kube-root-ca.crt"
+                            }
+                        },
+                        {
+                            "downwardAPI": {
+                                "items": [
+                                    {
+                                        "fieldRef": {
+                                            "apiVersion": "v1",
+                                            "fieldPath": "metadata.namespace"
+                                        },
+                                        "path": "namespace"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+   
+}

--- a/workloadinterface/testdata/workloadmethods/podstatusrunning.json
+++ b/workloadinterface/testdata/workloadmethods/podstatusrunning.json
@@ -1,0 +1,167 @@
+{
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+        "annotations": {
+            "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"nginx:1.15\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}]}]}}\n"
+        },
+        "creationTimestamp": "2023-02-02T12:49:54Z",
+        "name": "nginx",
+        "namespace": "default",
+        "resourceVersion": "64138",
+        "uid": "c67b47c0-d12e-4505-ae90-f24f2125bec6"
+    },
+    "spec": {
+        "containers": [
+            {
+                "image": "nginx:1.15",
+                "imagePullPolicy": "IfNotPresent",
+                "name": "nginx",
+                "ports": [
+                    {
+                        "containerPort": 80,
+                        "protocol": "TCP"
+                    }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "terminationMessagePolicy": "File",
+                "volumeMounts": [
+                    {
+                        "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                        "name": "kube-api-access-2k5s7",
+                        "readOnly": true
+                    }
+                ]
+            }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "enableServiceLinks": true,
+        "nodeName": "minikube",
+        "preemptionPolicy": "PreemptLowerPriority",
+        "priority": 0,
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "tolerations": [
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/not-ready",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            },
+            {
+                "effect": "NoExecute",
+                "key": "node.kubernetes.io/unreachable",
+                "operator": "Exists",
+                "tolerationSeconds": 300
+            }
+        ],
+        "volumes": [
+            {
+                "name": "kube-api-access-2k5s7",
+                "projected": {
+                    "defaultMode": 420,
+                    "sources": [
+                        {
+                            "serviceAccountToken": {
+                                "expirationSeconds": 3607,
+                                "path": "token"
+                            }
+                        },
+                        {
+                            "configMap": {
+                                "items": [
+                                    {
+                                        "key": "ca.crt",
+                                        "path": "ca.crt"
+                                    }
+                                ],
+                                "name": "kube-root-ca.crt"
+                            }
+                        },
+                        {
+                            "downwardAPI": {
+                                "items": [
+                                    {
+                                        "fieldRef": {
+                                            "apiVersion": "v1",
+                                            "fieldPath": "metadata.namespace"
+                                        },
+                                        "path": "namespace"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2023-02-02T12:49:54Z",
+                "status": "True",
+                "type": "Initialized"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2023-02-02T12:49:56Z",
+                "status": "True",
+                "type": "Ready"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2023-02-02T12:49:56Z",
+                "status": "True",
+                "type": "ContainersReady"
+            },
+            {
+                "lastProbeTime": null,
+                "lastTransitionTime": "2023-02-02T12:49:54Z",
+                "status": "True",
+                "type": "PodScheduled"
+            }
+        ],
+        "containerStatuses": [
+            {
+                "containerID": "docker://eaa18d12e7eced5a1e40be182fc35f6f9f1ba6475beb70e05ca5629b6d82f59c",
+                "image": "nginx:1.15",
+                "imageID": "docker-pullable://nginx@sha256:23b4dcdf0d34d4a129755fc6f52e1c6e23bb34ea011b315d87e193033bcd1b68",
+                "lastState": {
+                    "terminated": {
+                        "containerID": "docker://f614a910674304cb8deef6c68fb6a80cc791737cf27d4cf5422e0a153ad6a331",
+                        "exitCode": 0,
+                        "finishedAt": "2023-02-02T12:50:47Z",
+                        "reason": "Completed",
+                        "startedAt": "2023-02-02T12:49:55Z"
+                    }
+                },
+                "name": "nginx",
+                "ready": true,
+                "restartCount": 1,
+                "started": true,
+                "state": {
+                    "running": {
+                        "startedAt": "2023-02-02T12:50:48Z"
+                    }
+                }
+            }
+        ],
+        "hostIP": "192.168.76.2",
+        "phase": "Running",
+        "podIP": "172.17.0.3",
+        "podIPs": [
+            {
+                "ip": "172.17.0.3"
+            }
+        ],
+        "qosClass": "BestEffort",
+        "startTime": "2023-02-02T12:49:54Z"
+    }
+}

--- a/workloadinterface/workloadmethods.go
+++ b/workloadinterface/workloadmethods.go
@@ -671,3 +671,18 @@ func (w *Workload) GetConfigMaps() ([]string, error) {
 	}
 	return configMaps, nil
 }
+
+func (w *Workload) GetPodStatus() (*corev1.PodStatus, error) {
+	status := corev1.PodStatus{}
+	if v, ok := InspectWorkload(w.workload, "status"); ok && v != nil {
+		vBytes, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(vBytes, &status)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &status, nil
+}

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -43,6 +43,12 @@ var (
 	//go:embed testdata/workloadmethods/multipleconfigmapssamename.json
 	multipleConfigMapsSameName string
 
+	//go:embed testdata/workloadmethods/podstatusrunning.json
+	podStatusRunning string
+
+	//go:embed testdata/workloadmethods/podstatusnotpresent.json
+	podStatusNotPresent string
+
 	mockDeployment = `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1"},"creationTimestamp":"2021-05-03T13:10:32Z","generation":1,"managedFields":[{"apiVersion":"apps/v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:app":{},"f:cyberarmor.inject":{}}},"f:spec":{"f:progressDeadlineSeconds":{},"f:replicas":{},"f:revisionHistoryLimit":{},"f:selector":{},"f:strategy":{"f:rollingUpdate":{".":{},"f:maxSurge":{},"f:maxUnavailable":{}},"f:type":{}},"f:template":{"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:containers":{"k:{\"name\":\"demoservice\"}":{".":{},"f:env":{".":{},"k:{\"name\":\"ARMO_TEST_NAME\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"CAA_ENABLE_CRASH_REPORTER\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"DEMO_FOLDERS\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"SERVER_PORT\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"SLEEP_DURATION\"}":{".":{},"f:name":{},"f:value":{}}},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:ports":{".":{},"k:{\"containerPort\":8089,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:protocol":{}}},"f:resources":{},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{}}},"f:dnsPolicy":{},"f:restartPolicy":{},"f:schedulerName":{},"f:securityContext":{},"f:terminationGracePeriodSeconds":{}}}}},"manager":"OpenAPI-Generator","operation":"Update","time":"2021-05-03T13:10:32Z"},{"apiVersion":"apps/v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:deployment.kubernetes.io/revision":{}}},"f:status":{"f:availableReplicas":{},"f:conditions":{".":{},"k:{\"type\":\"Available\"}":{".":{},"f:lastTransitionTime":{},"f:lastUpdateTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}},"k:{\"type\":\"Progressing\"}":{".":{},"f:lastTransitionTime":{},"f:lastUpdateTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}}},"f:observedGeneration":{},"f:readyReplicas":{},"f:replicas":{},"f:updatedReplicas":{}}},"manager":"kube-controller-manager","operation":"Update","time":"2021-05-03T13:52:58Z"}],"name":"demoservice-server","namespace":"default","resourceVersion":"1016043","uid":"e9e8a3e9-6cb4-4301-ace1-2c0cef3bd61e"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app":"demoservice-server"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"demoservice-server"}},"spec":{"containers":[{"env":[{"name":"SERVER_PORT","value":"8089"},{"name":"SLEEP_DURATION","value":"1"},{"name":"DEMO_FOLDERS","value":"/app"},{"name":"ARMO_TEST_NAME","value":"auto_attach_deployment"},{"name":"CAA_ENABLE_CRASH_REPORTER","value":"1"}],"image":"quay.io/armosec/demoservice:v25","imagePullPolicy":"IfNotPresent","name":"demoservice","ports":[{"containerPort":8089,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File"}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30}}},"status":{"availableReplicas":1,"conditions":[{"lastTransitionTime":"2021-05-03T13:10:32Z","lastUpdateTime":"2021-05-03T13:10:37Z","message":"ReplicaSet \"demoservice-server-7d478b6998\" has successfully progressed.","reason":"NewReplicaSetAvailable","status":"True","type":"Progressing"},{"lastTransitionTime":"2021-05-03T13:52:58Z","lastUpdateTime":"2021-05-03T13:52:58Z","message":"Deployment has minimum availability.","reason":"MinimumReplicasAvailable","status":"True","type":"Available"}],"observedGeneration":1,"readyReplicas":1,"replicas":1,"updatedReplicas":1}}`
 	mockService    = `{"apiVersion":"v1","kind":"Service","metadata":{"creationTimestamp":"2021-12-06T14:01:16Z","labels":{"app":"armo-vuln-scan","app.kubernetes.io\/managed-by":"Helm"},"name":"armo-vuln-scan","resourceVersion":"351796","uid":"12bd4f9f-3ec6-4113-8ec6-0b8a1c772deb"},"spec":{"clusterIP":"10.107.7.78","clusterIPs":["10.107.7.78"],"internalTrafficPolicy":"Cluster","ipFamilies":["IPv4"],"ipFamilyPolicy":"SingleStack","ports":[{"port":8080,"protocol":"TCP","targetPort":8080}],"selector":{"app":"armo-vuln-scan"},"sessionAffinity":"None","type":"ClusterIP"},"status":{"loadBalancer":{}}}`
 )
@@ -455,6 +461,41 @@ func TestGetConfigMaps(t *testing.T) {
 			sort.Strings(tc.want)
 			sort.Strings(configMaps)
 			assert.Equal(t, tc.want, configMaps)
+		})
+	}
+
+}
+
+func TestGetPodStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		want          string
+		responseError error
+		mockData      string
+	}{
+		{
+			name:          "Pod status running",
+			want:          "Running",
+			responseError: nil,
+			mockData:      podStatusRunning,
+		},
+		{
+			name:          "Pod status not present",
+			want:          "",
+			responseError: nil,
+			mockData:      podStatusNotPresent,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workload, err := NewWorkload([]byte(tc.mockData))
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			podStatus, err := workload.GetPodStatus()
+			assert.Equal(t, string(podStatus.Phase), tc.want)
+			assert.Equal(t, err, tc.responseError)
 		})
 	}
 

--- a/workloadinterface/workloadmock.go
+++ b/workloadinterface/workloadmock.go
@@ -285,3 +285,7 @@ func (wm *WorkloadMock) GetSecrets() ([]string, error) {
 func (wm *WorkloadMock) GetConfigMaps() ([]string, error) {
 	return wm.workload.GetConfigMaps()
 }
+
+func (wm *WorkloadMock) GetPodStatus() (*corev1.PodStatus, error) {
+	return wm.workload.GetPodStatus()
+}


### PR DESCRIPTION
1 - add `GetPodStatus` function
2 - Change `ListPods` to return an object of type `*corev1.PodList`, instead of returning just the list of Pods themselves. The reason is since some clients may need to access data from the PodList object, such as ResourceVersion, and we shouldn't limit it.