### PR TITLE
feat(cloudsupport): implement get-policy-version funtionality

### DIFF
--- a/cloudsupport/apis/apis.go
+++ b/cloudsupport/apis/apis.go
@@ -13,6 +13,7 @@ const (
 	CloudProviderDescribeKind                = "ClusterDescribe"
 	CloudProviderDescribeRepositoriesKind    = "DescribeRepositories"
 	CloudProviderListEntitiesForPoliciesKind = "ListEntitiesForPolicies"
+	CloudProviderPolicyVersionKind           = "PolicyVersion"
 )
 
 // IsTypeDescriptiveInfoFromCloudProvider return true if the object apiVersion kind match the CloudProviderDescribeKind struct
@@ -29,6 +30,11 @@ func IsTypeDescribeRepositories(object map[string]interface{}) bool {
 // IsTypeListEntitiesForPolicies return true if the object apiVersion kind match the CloudProviderListEntitiesForPoliciesKind struct
 func IsTypeListEntitiesForPolicies(object map[string]interface{}) bool {
 	return IsCloudProviderType(object, []string{CloudProviderListEntitiesForPoliciesKind})
+}
+
+// IsTypePolicyVersion return true if the object apiVersion kind match the CloudProviderPolicyVersion struct
+func IsTypePolicyVersion(object map[string]interface{}) bool {
+	return IsCloudProviderType(object, []string{CloudProviderPolicyVersionKind})
 }
 
 func IsCloudProviderType(object map[string]interface{}, acceptableTypes []string) bool {

--- a/cloudsupport/cloudproviderconfiguration.go
+++ b/cloudsupport/cloudproviderconfiguration.go
@@ -151,3 +151,29 @@ func GetListEntitiesForPoliciesFromCloudProvider(cluster string, cloudProvider s
 
 	return listEntitiesForPolicies, nil
 }
+
+// GetPolicyVersionFromCloudProvider returns PolicyVersion from the cloud provider wrapped in IMetadata obj
+func GetPolicyVersionFromCloudProvider(cluster string, cloudProvider string) (workloadinterface.IMetadata, error) {
+	var policyVersion *cloudsupportv1.CloudProviderPolicyVersion
+
+	switch cloudProvider {
+	case cloudsupportv1.EKS:
+		eksSupport := cloudsupportv1.NewEKSSupport()
+		region, err := eksSupport.GetRegion(cluster)
+		if err != nil {
+			return nil, err
+		}
+		policyVersion, err = cloudsupportv1.GetPolicyVersionEKS(eksSupport, cluster, region)
+		if err != nil {
+			return nil, err
+		}
+	case cloudsupportv1.GKE:
+		//TODO - implement GKE support
+		return nil, fmt.Errorf(cloudsupportv1.NotSupportedMsg)
+	case cloudsupportv1.AKS:
+		//TODO - implement AKS support
+		return nil, fmt.Errorf(cloudsupportv1.NotSupportedMsg)
+	}
+
+	return policyVersion, nil
+}

--- a/cloudsupport/mockobjects/cloudmockobjects.go
+++ b/cloudsupport/mockobjects/cloudmockobjects.go
@@ -404,3 +404,55 @@ var EksListEntitiesForPolicies = `
     }
 }
         `
+var EksGetPolicyVersion = `
+{
+    "apiVersion": "eks.amazonaws.com/v1",
+    "kind": "PolicyVersion",
+    "metadata": {
+        "name": "ca-terraform-eks-dev-stage",
+        "provider": "eks"
+    },
+    "data": {
+        "policiesDocuments": {
+            "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "ecr:GetAuthorizationToken",
+                            "ecr:BatchCheckLayerAvailability",
+                            "ecr:GetDownloadUrlForLayer",
+                            "ecr:GetRepositoryPolicy",
+                            "ecr:DescribeRepositories",
+                            "ecr:ListImages",
+                            "ecr:DescribeImages",
+                            "ecr:BatchGetImage",
+                            "ecr:GetLifecyclePolicy",
+                            "ecr:GetLifecyclePolicyPreview",
+                            "ecr:ListTagsForResource",
+                            "ecr:DescribeImageScanFindings"
+                        ],
+                        "Resource": "*"
+                    }
+                ]
+            },
+            "arn:aws:iam::aws:policy/AWSMarketplaceFullAccess": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": "ec2:*",
+                        "Effect": "Allow",
+                        "Resource": "*"
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": "elasticloadbalancing:*",
+                        "Resource": "*"
+                    }
+                ]
+            }
+        }
+    }
+}
+`

--- a/cloudsupport/v1/cloudproviderv1_test.go
+++ b/cloudsupport/v1/cloudproviderv1_test.go
@@ -30,6 +30,58 @@ func TestGetClusterDescribeEKS(t *testing.T) {
 	//assert.Equal(t, 1, len(des.GetData()))
 }
 
+// ==================== GetPolicyVersion ====================
+
+func TestGetPolicyVersion(t *testing.T) {
+	//TODO: Add more tests
+	g := NewEKSSupportMock()
+	repos, err := GetPolicyVersionEKS(g, "ca-terraform-eks-dev-stage", "")
+	assert.NoError(t, err)
+	assert.Equal(t, apis.CloudProviderPolicyVersionKind, repos.GetKind())
+	assert.Equal(t, "eks.amazonaws.com/v1/PolicyVersion/ca-terraform-eks-dev-stage", repos.GetID())
+	assert.Equal(t, k8sinterface.JoinGroupVersion(apis.ApiVersionEKS, Version), repos.GetApiVersion())
+	assert.Equal(t, "ca-terraform-eks-dev-stage", repos.GetName())
+	assert.Equal(t, TypeCloudProviderPolicyVersion, repos.GetObjectType())
+}
+
+func TestSetApiVersionGetPolicyVersion(t *testing.T) {
+	repos := &CloudProviderPolicyVersion{ApiVersion: "eks.amazonaws.com/v1"}
+	repos.SetApiVersion(apis.ApiVersionEKS)
+	assert.Equal(t, repos.ApiVersion, apis.ApiVersionEKS)
+}
+
+func TestSetNameGetPolicyVersion(t *testing.T) {
+	repos := &CloudProviderPolicyVersion{Metadata: CloudProviderMetadata{Name: "ca-terraform-eks-dev-stage"}}
+	repos.SetName("new-name")
+	assert.Equal(t, repos.Metadata.Name, "new-name")
+}
+
+func TestSetKindGetPolicyVersion(t *testing.T) {
+	repos := &CloudProviderPolicyVersion{Kind: "PolicyVersion"}
+	repos.SetKind("new-kind")
+	assert.Equal(t, repos.Kind, "new-kind")
+}
+
+func TestSetObjectGetPolicyVersion(t *testing.T) {
+	repos := &CloudProviderPolicyVersion{}
+	repos.SetObject(map[string]interface{}{
+		"kind": "PolicyVersion", "apiVersion": "eks.amazonaws.com/v1", "metadata": map[string]interface{}{"name": "new-object", "provider": "b"}})
+	assert.Equal(t, repos.GetObject(), map[string]interface{}{
+		"kind": "PolicyVersion", "apiVersion": "eks.amazonaws.com/v1", "data": interface{}(nil),
+		"metadata": map[string]interface{}{"name": "new-object", "provider": "b"}})
+}
+
+func TestSetWorkloadGetPolicyVersion(t *testing.T) {
+	repos := &CloudProviderPolicyVersion{}
+	repos.SetWorkload(map[string]interface{}{
+		"kind": "PolicyVersion", "apiVersion": "eks.amazonaws.com/v1",
+		"metadata": map[string]interface{}{"name": "new-workload", "provider": "bla"}})
+	assert.Equal(t, repos.GetObject(), map[string]interface{}{
+		"kind": "PolicyVersion", "apiVersion": "eks.amazonaws.com/v1", "data": interface{}(nil),
+		"metadata": map[string]interface{}{"name": "new-workload", "provider": "bla"}})
+
+}
+
 // ==================== ListEntitiesForPolicies ====================
 func TestGetListEntitiesForPoliciesEKS(t *testing.T) {
 	//TODO: Add more tests

--- a/cloudsupport/v1/datastructures.go
+++ b/cloudsupport/v1/datastructures.go
@@ -56,3 +56,16 @@ type CloudProviderListEntitiesForPolicies struct {
 	Metadata   CloudProviderMetadata  `json:"metadata"`
 	Data       map[string]interface{} `json:"data"`
 }
+
+/*
+CloudProviderPolicyVersion:
+=========================
+
+CloudProviderPolicyVersion has a list of the PolicyVersion in the cloud provider (EKS)
+*/
+type CloudProviderPolicyVersion struct {
+	ApiVersion string                 `json:"apiVersion"`
+	Kind       string                 `json:"kind"`
+	Metadata   CloudProviderMetadata  `json:"metadata"`
+	Data       map[string]interface{} `json:"data"`
+}

--- a/cloudsupport/v1/ekssupportmock.go
+++ b/cloudsupport/v1/ekssupportmock.go
@@ -38,6 +38,13 @@ func (eksSupportM *EKSSupportMock) GetListEntitiesForPolicies(region string) (*L
 	return listEntitiesForPoliciesOutput, err
 }
 
+// GetPolicyVersion
+func (eksSupportM *EKSSupportMock) GetPolicyVersion(region string) (*ListPolicyVersion, error) {
+	policyVersionContent := &ListPolicyVersion{}
+	err := json.Unmarshal([]byte(mockobjects.EksGetPolicyVersion), policyVersionContent)
+	return policyVersionContent, err
+}
+
 // getName get cluster name from describe
 func (eksSupportM *EKSSupportMock) GetName(describe *eks.DescribeClusterOutput) string {
 	return *describe.Cluster.Name

--- a/cloudsupport/v1/methods.go
+++ b/cloudsupport/v1/methods.go
@@ -318,3 +318,99 @@ func (description *CloudProviderListEntitiesForPolicies) GetObject() map[string]
 func (description *CloudProviderListEntitiesForPolicies) GetID() string {
 	return fmt.Sprintf("%s/%s/%s", k8sinterface.JoinGroupVersion(k8sinterface.SplitApiVersion(description.GetApiVersion())), description.GetKind(), description.GetName())
 }
+
+// ==========================================================================================================
+// ============================== CloudProviderPolicyVersion ==================================================
+// ==========================================================================================================
+// Setters
+func (description *CloudProviderPolicyVersion) SetNamespace(namespace string) {
+	description.SetProvider(namespace)
+}
+
+func (description *CloudProviderPolicyVersion) SetApiVersion(apiVersion string) {
+	description.ApiVersion = apiVersion
+}
+
+func (description *CloudProviderPolicyVersion) SetName(name string) {
+	description.Metadata.SetName(name)
+}
+
+func (description *CloudProviderPolicyVersion) SetProvider(provider string) {
+	description.Metadata.SetProvider(provider)
+}
+
+func (description *CloudProviderPolicyVersion) SetKind(kind string) {
+	description.Kind = kind
+}
+
+func (description *CloudProviderPolicyVersion) SetData(data map[string]interface{}) {
+	description.Data = data
+}
+
+func (description *CloudProviderPolicyVersion) SetWorkload(object map[string]interface{}) {
+	description.SetObject(object)
+}
+
+func (description *CloudProviderPolicyVersion) SetObject(object map[string]interface{}) {
+	if !apis.IsTypePolicyVersion(object) {
+		return
+	}
+	if b := workloadinterface.MapToBytes(object); len(b) > 0 {
+		d := &CloudProviderPolicyVersion{}
+		if err := json.Unmarshal(b, d); err == nil {
+			description.SetApiVersion(d.GetApiVersion())
+			description.SetKind(d.GetKind())
+			description.SetData(d.GetData())
+			description.Metadata = d.Metadata
+		}
+	}
+}
+
+// Getters
+
+func (description *CloudProviderPolicyVersion) GetApiVersion() string {
+	return description.ApiVersion
+}
+
+func (description *CloudProviderPolicyVersion) GetObjectType() workloadinterface.ObjectType {
+	return TypeCloudProviderPolicyVersion
+}
+func (description *CloudProviderPolicyVersion) GetKind() string {
+	return description.Kind
+}
+
+func (description *CloudProviderPolicyVersion) GetName() string {
+	return description.Metadata.GetName()
+}
+
+// provider -> eks/gke/etc.
+func (description *CloudProviderPolicyVersion) GetProvider() string {
+	return description.Metadata.GetProvider()
+}
+
+// Compatible with the IMetadata interface
+func (description *CloudProviderPolicyVersion) GetNamespace() string {
+	return description.GetProvider()
+}
+
+func (description *CloudProviderPolicyVersion) GetWorkload() map[string]interface{} {
+	return description.GetObject()
+}
+
+func (description *CloudProviderPolicyVersion) GetData() map[string]interface{} {
+	return description.Data
+}
+
+func (description *CloudProviderPolicyVersion) GetObject() map[string]interface{} {
+	m := map[string]interface{}{}
+	b, err := json.Marshal(*description)
+	if err != nil {
+		return m
+	}
+	return workloadinterface.BytesToMap(b)
+}
+
+// ApiVersion/Kind/Name
+func (description *CloudProviderPolicyVersion) GetID() string {
+	return fmt.Sprintf("%s/%s/%s", k8sinterface.JoinGroupVersion(k8sinterface.SplitApiVersion(description.GetApiVersion())), description.GetKind(), description.GetName())
+}


### PR DESCRIPTION
This feature implement the following command from `aws` cli:
```
aws iam get-policy-version --version-id v3 --policy-arn arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
```
In this way, we will be able to retrieve policy version contents from AWS and provide them to the **rego** rules.
More specifically, we are filling the missing data for this issue: [SUB-610](https://cyberarmor-io.atlassian.net/browse/SUB-610).
Here's an example about what we are going to have:
```
{
    "apiVersion": "eks.amazonaws.com/v1",
    "kind": "PolicyVersion",
    "metadata": {
        "name": "ca-terraform-eks-dev-stage",
        "provider": "eks"
    },
    "data": {
        "policiesDocuments": {
            "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly": {
                        "Version": "2012-10-17",
                        "Statement": [
                            {
                                "Effect": "Allow",
                                "Action": [
                                    "ecr:GetAuthorizationToken",
                                    "ecr:BatchCheckLayerAvailability",
                                    "ecr:GetDownloadUrlForLayer",
                                    "ecr:GetRepositoryPolicy",
                                    "ecr:DescribeRepositories",
                                    "ecr:ListImages",
                                    "ecr:DescribeImages",
                                    "ecr:BatchGetImage",
                                    "ecr:GetLifecyclePolicy",
                                    "ecr:GetLifecyclePolicyPreview",
                                    "ecr:ListTagsForResource",
                                    "ecr:DescribeImageScanFindings"
                                ],
                                "Resource": "*"
                            }
                        ]
            },
            "arn:aws:iam::aws:policy/AWSMarketplaceFullAccess": {
                        "Version": "2012-10-17",
                        "Statement": [
                            {
                                "Action": "ec2:*",
                                "Effect": "Allow",
                                "Resource": "*"
                            },
                            {
                                "Effect": "Allow",
                                "Action": "elasticloadbalancing:*",
                                "Resource": "*"
                            },
                            {
                                "Effect": "Allow",
                                "Action": "cloudwatch:*",
                                "Resource": "*"
                            },
                            {
                                "Effect": "Allow",
                                "Action": "autoscaling:*",
                                "Resource": "*"
                            },
                            {
                                "Effect": "Allow",
                                "Action": "iam:CreateServiceLinkedRole",
                                "Resource": "*",
                                "Condition": {
                                    "StringEquals": {
                                        "iam:AWSServiceName": [
                                            "autoscaling.amazonaws.com",
                                            "ec2scheduled.amazonaws.com",
                                            "elasticloadbalancing.amazonaws.com",
                                            "spot.amazonaws.com",
                                            "spotfleet.amazonaws.com",
                                            "transitgateway.amazonaws.com"
                                        ]
                                    }
                                }
                            }
                }
            }
        }
    }
}
```