### PR TITLE
fix(instanceidhandler): remove unused error

### DIFF
--- a/instanceidhandler/errors.go
+++ b/instanceidhandler/errors.go
@@ -1,7 +1,0 @@
-package instanceidhandler
-
-import "errors"
-
-var (
-	ErrInvalidFriendlyName = errors.New("Current inputs produce an invalid friendly name")
-)


### PR DESCRIPTION
# What this PR changes?
A previous commit has erroneusly introduced an exported error which was never used anywhere. This commit removes the error.