### PR TITLE
Fixing Cluster Server Name Retrieval and Adding Corresponding Tests

### DIFF
--- a/k8sinterface/k8sconfig.go
+++ b/k8sinterface/k8sconfig.go
@@ -186,13 +186,24 @@ func SetConfigClusterServerName(contextName string) {
 	ConfigClusterServerName = contextName
 }
 
+// GetK8sConfigClusterServerName get the server name of desired cluster context
 func GetK8sConfigClusterServerName(config *clientcmdapi.Config) string {
-	if config != nil {
-		if ConfigClusterServerName == "" {
-			if _, exist := config.Clusters[config.CurrentContext]; exist {
-				ConfigClusterServerName = config.Clusters[config.CurrentContext].Server
-			}
-		}
+	if config == nil {
+		return ConfigClusterServerName
 	}
+
+	contextName := ConfigClusterServerName
+	if contextName == "" {
+		// if context name is not set, use the current context
+		contextName = config.CurrentContext
+		SetClusterContextName(contextName)
+	}
+
+	if context, exist := config.Clusters[contextName]; exist {
+		// return the server name of the context
+		return context.Server
+	}
+
+	// return current context in case the server name is not available
 	return ConfigClusterServerName
 }

--- a/k8sinterface/k8sconfig.go
+++ b/k8sinterface/k8sconfig.go
@@ -199,7 +199,7 @@ func GetK8sConfigClusterServerName(config *clientcmdapi.Config) string {
 		SetClusterContextName(contextName)
 	}
 
-	if context, exist := config.Clusters[contextName]; exist {
+	if context, exist := config.Clusters[contextName]; exist && context != nil {
 		// return the server name of the context
 		return context.Server
 	}

--- a/k8sinterface/k8sconfig_test.go
+++ b/k8sinterface/k8sconfig_test.go
@@ -1,0 +1,63 @@
+package k8sinterface
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+func TestGetK8sConfigClusterServerName(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *clientcmdapi.Config
+		expectedServer string
+	}{
+		{
+			name:           "Config is nil, return default server name",
+			config:         nil,
+			expectedServer: ConfigClusterServerName,
+		},
+		{
+			name: "Context name is not set, return current context server name",
+			config: &clientcmdapi.Config{
+				CurrentContext: "test-context",
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test-context": {
+						Server: "https://test-server.com",
+					},
+				},
+			},
+			expectedServer: "https://test-server.com",
+		},
+		{
+			name: "Context name is set, return context server name",
+			config: &clientcmdapi.Config{
+				CurrentContext: "test-context",
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test-context": {
+						Server: "https://test-server.com",
+					},
+				},
+			},
+			expectedServer: "https://test-server.com",
+		},
+		{
+			name: "Context name is set, but server name is not available, return default server name",
+			config: &clientcmdapi.Config{
+				CurrentContext: "test-context",
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"test-context": {},
+				},
+			},
+			expectedServer: ConfigClusterServerName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualServer := GetK8sConfigClusterServerName(tt.config)
+			assert.Equal(t, tt.expectedServer, actualServer)
+		})
+	}
+}


### PR DESCRIPTION
## PR Type:
Bug fix, Tests
Resolves: [After upgrade to 2.9.0 framework cis-aks-t1.2.0 not working](https://github.com/kubescape/kubescape/issues/1350)

___
## PR Description:
This PR addresses an issue with the retrieval of the server name of a desired cluster context. The logic has been updated to handle different scenarios more accurately. Additionally, tests have been added to ensure the correct functionality of the updated method.

___
## PR Main Files Walkthrough:
`k8sinterface/k8sconfig.go`: Updated the GetK8sConfigClusterServerName function to handle different scenarios such as when the config is nil, when the context name is not set, and when the server name is not available. The function now returns the appropriate server name based on these conditions.
`k8sinterface/k8sconfig_test.go`: Added tests for the GetK8sConfigClusterServerName function. These tests cover different scenarios to ensure the function behaves as expected.
