### PR TITLE
check for nil value in  labels

### DIFF
--- a/workloadinterface/testdata/workloadmethods/deploymentWithemptyLabels.json
+++ b/workloadinterface/testdata/workloadmethods/deploymentWithemptyLabels.json
@@ -1,0 +1,43 @@
+{
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "name": "my-deployment",
+      "labels": {
+        "app": "my-app",
+        "version": "1.0",
+        "env": null,
+        "team": null
+      }
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "my-app"
+        }
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "my-app",
+            "version": "1.0"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "name": "my-container",
+              "image": "my-image:latest",
+              "ports": [
+                {
+                  "containerPort": 80
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+  

--- a/workloadinterface/workloadmethods.go
+++ b/workloadinterface/workloadmethods.go
@@ -332,6 +332,11 @@ func (w *Workload) GetLabels() map[string]string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "labels"); ok && v != nil {
 		labels := make(map[string]string)
 		for k, i := range v.(map[string]interface{}) {
+			// null labels will be ignored
+			if i == nil {
+				continue
+			}
+
 			labels[k] = i.(string)
 		}
 		return labels

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -49,6 +49,9 @@ var (
 	//go:embed testdata/workloadmethods/podstatusnotpresent.json
 	podStatusNotPresent string
 
+	//go:embed testdata/workloadmethods/deploymentWithemptyLabels.json
+	deploymentWithemptyLabels string
+
 	mockDeployment = `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1"},"creationTimestamp":"2021-05-03T13:10:32Z","generation":1,"managedFields":[{"apiVersion":"apps/v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:app":{},"f:cyberarmor.inject":{}}},"f:spec":{"f:progressDeadlineSeconds":{},"f:replicas":{},"f:revisionHistoryLimit":{},"f:selector":{},"f:strategy":{"f:rollingUpdate":{".":{},"f:maxSurge":{},"f:maxUnavailable":{}},"f:type":{}},"f:template":{"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:containers":{"k:{\"name\":\"demoservice\"}":{".":{},"f:env":{".":{},"k:{\"name\":\"ARMO_TEST_NAME\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"CAA_ENABLE_CRASH_REPORTER\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"DEMO_FOLDERS\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"SERVER_PORT\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"SLEEP_DURATION\"}":{".":{},"f:name":{},"f:value":{}}},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:ports":{".":{},"k:{\"containerPort\":8089,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:protocol":{}}},"f:resources":{},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{}}},"f:dnsPolicy":{},"f:restartPolicy":{},"f:schedulerName":{},"f:securityContext":{},"f:terminationGracePeriodSeconds":{}}}}},"manager":"OpenAPI-Generator","operation":"Update","time":"2021-05-03T13:10:32Z"},{"apiVersion":"apps/v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:deployment.kubernetes.io/revision":{}}},"f:status":{"f:availableReplicas":{},"f:conditions":{".":{},"k:{\"type\":\"Available\"}":{".":{},"f:lastTransitionTime":{},"f:lastUpdateTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}},"k:{\"type\":\"Progressing\"}":{".":{},"f:lastTransitionTime":{},"f:lastUpdateTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}}},"f:observedGeneration":{},"f:readyReplicas":{},"f:replicas":{},"f:updatedReplicas":{}}},"manager":"kube-controller-manager","operation":"Update","time":"2021-05-03T13:52:58Z"}],"name":"demoservice-server","namespace":"default","resourceVersion":"1016043","uid":"e9e8a3e9-6cb4-4301-ace1-2c0cef3bd61e"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app":"demoservice-server"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"demoservice-server"}},"spec":{"containers":[{"env":[{"name":"SERVER_PORT","value":"8089"},{"name":"SLEEP_DURATION","value":"1"},{"name":"DEMO_FOLDERS","value":"/app"},{"name":"ARMO_TEST_NAME","value":"auto_attach_deployment"},{"name":"CAA_ENABLE_CRASH_REPORTER","value":"1"}],"image":"quay.io/armosec/demoservice:v25","imagePullPolicy":"IfNotPresent","name":"demoservice","ports":[{"containerPort":8089,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File"}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30}}},"status":{"availableReplicas":1,"conditions":[{"lastTransitionTime":"2021-05-03T13:10:32Z","lastUpdateTime":"2021-05-03T13:10:37Z","message":"ReplicaSet \"demoservice-server-7d478b6998\" has successfully progressed.","reason":"NewReplicaSetAvailable","status":"True","type":"Progressing"},{"lastTransitionTime":"2021-05-03T13:52:58Z","lastUpdateTime":"2021-05-03T13:52:58Z","message":"Deployment has minimum availability.","reason":"MinimumReplicasAvailable","status":"True","type":"Available"}],"observedGeneration":1,"readyReplicas":1,"replicas":1,"updatedReplicas":1}}`
 	mockService    = `{"apiVersion":"v1","kind":"Service","metadata":{"creationTimestamp":"2021-12-06T14:01:16Z","labels":{"app":"armo-vuln-scan","app.kubernetes.io\/managed-by":"Helm"},"name":"armo-vuln-scan","resourceVersion":"351796","uid":"12bd4f9f-3ec6-4113-8ec6-0b8a1c772deb"},"spec":{"clusterIP":"10.107.7.78","clusterIPs":["10.107.7.78"],"internalTrafficPolicy":"Cluster","ipFamilies":["IPv4"],"ipFamilyPolicy":"SingleStack","ports":[{"port":8080,"protocol":"TCP","targetPort":8080}],"selector":{"app":"armo-vuln-scan"},"sessionAffinity":"None","type":"ClusterIP"},"status":{"loadBalancer":{}}}`
 )
@@ -496,6 +499,32 @@ func TestGetPodStatus(t *testing.T) {
 			podStatus, err := workload.GetPodStatus()
 			assert.Equal(t, string(podStatus.Phase), tc.want)
 			assert.Equal(t, err, tc.responseError)
+		})
+	}
+
+}
+
+func TestGetLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		want     map[string]string
+		mockData string
+	}{
+		{
+			name:     "null labels will not be returned",
+			want:     map[string]string{"app": "my-app", "version": "1.0"},
+			mockData: deploymentWithemptyLabels,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workload, err := NewWorkload([]byte(tc.mockData))
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			labels := workload.GetLabels()
+			assert.Equal(t, tc.want, labels)
 		})
 	}
 


### PR DESCRIPTION
## PR Type:
Bug fix, Tests

___
## PR Description:
This PR addresses a bug where the `GetLabels` method was causing a panic when a label value was nil. The fix involves checking for nil values and ignoring them. Additionally, a test case has been added to ensure that null labels are not returned.

___
## PR Main Files Walkthrough:
`workloadinterface/workloadmethods.go`: Added a check for nil values in the `GetLabels` method. If a label value is nil, it is now ignored.
`workloadinterface/workloadmethods_test.go`: Added a new test case for the `GetLabels` method to ensure that null labels are not returned.
`workloadinterface/testdata/workloadmethods/deploymentWithemptyLabels.json`: Added a new test data file that contains a deployment with null labels. This is used in the new test case for the `GetLabels` method.

___
## User Description:
`GetLabels` was panicking when a value of a label was nil
