### PR TITLE
Ignore forbidden resources

### DIFF
--- a/k8sinterface/k8sdiscovery.go
+++ b/k8sinterface/k8sdiscovery.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	ValueNotFound       = -1
-	ResourceNotFoundErr = "resource not found"
+	ValueNotFound        = -1
+	ResourceNotFoundErr  = "resource not found"
+	ResourceForbiddenErr = "is forbidden"
 )
 
 // ResourceGroupMapping mapping of all supported Kubernetes cluster resources to apiVersion

--- a/k8sinterface/k8sdynamic.go
+++ b/k8sinterface/k8sdynamic.go
@@ -208,7 +208,7 @@ func (k8sAPI *KubernetesApi) CalculateWorkloadParentRecursive(workload IWorkload
 
 	parentWorkload, err := k8sAPI.GetWorkload(workload.GetNamespace(), ownerKind, ownerName)
 	if err != nil {
-		if strings.Contains(err.Error(), ResourceNotFoundErr) { // if parent is CRD
+		if strings.Contains(err.Error(), ResourceNotFoundErr) || strings.Contains(err.Error(), ResourceForbiddenErr) { // if parent is CRD
 			return workload.GetKind(), workload.GetName(), nil // parent found
 		}
 		return workload.GetKind(), workload.GetName(), err


### PR DESCRIPTION
In case the parent is forbidden, we assume it is a CRD and therefor ignore it.