### PR TITLE
Get cloud provider from the nodes labels

### DIFF
--- a/cloudsupport/cloudproviderconfiguration.go
+++ b/cloudsupport/cloudproviderconfiguration.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	cloudsupportv1 "github.com/kubescape/k8s-interface/cloudsupport/v1"
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
@@ -36,8 +38,8 @@ func GetKubeContextName() string {
 }
 
 // GetCloudProvider returns the cloud provider name
-func GetCloudProvider() string {
-	return cloudsupportv1.GetCloudProvider()
+func GetCloudProvider(nodeList *corev1.NodeList) string {
+	return cloudsupportv1.GetCloudProvider(nodeList)
 }
 
 // GetDescriptiveInfoFromCloudProvider returns the cluster description from the cloud provider wrapped in IMetadata obj


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR refactors the method of detecting the cloud provider in the Kubescape project. Previously, the cloud provider was detected based on the gitVersion/server URL. Now, it is detected based on the labels of the nodes in the Kubernetes cluster. This change improves the accuracy of cloud provider detection.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`cloudsupport/cloudproviderconfiguration.go`: The GetCloudProvider function has been updated to accept a NodeList parameter. This is used to determine the cloud provider.
`cloudsupport/v1/cloudproviderv1.go`: The GetCloudProvider function has been updated to accept a NodeList parameter. The IsGKE, IsAKS functions have also been updated to use the NodeList for cloud provider detection. A new helper function, labelHasCloudPrefix, has been added to check if a node's labels contain a specific cloud prefix.
`cloudsupport/v1/cloudproviderv1_test.go`: The tests for IsGKE and GetCloudProvider have been updated to include a mock NodeList with specific labels. The test for IsAKS has been removed as the function now relies on the NodeList, which is tested in IsGKE.
</details>
