### PR TITLE
workload volume functions

### DIFF
--- a/workloadinterface/testdata/workloadmethods/podmountnohostvolume.json
+++ b/workloadinterface/testdata/workloadmethods/podmountnohostvolume.json
@@ -1,0 +1,134 @@
+{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "creationTimestamp": "2023-08-08T13:15:52Z",
+            "generateName": "mysql-8664b6d846-",
+            "labels": {
+                "app": "mysql",
+                "pod-template-hash": "8664b6d846"
+            },
+            "name": "mysql-8664b6d846-zfwhm",
+            "namespace": "default",
+            "ownerReferences": [
+                {
+                    "apiVersion": "apps/v1",
+                    "blockOwnerDeletion": true,
+                    "controller": true,
+                    "kind": "ReplicaSet",
+                    "name": "mysql-8664b6d846",
+                    "uid": "617a9d8f-4344-4db7-a92d-1938091f0eb4"
+                }
+            ],
+            "resourceVersion": "973",
+            "uid": "f8d132f1-7fc0-44ff-ae3f-39bf5622876e"
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name": "mysql",
+                    "image": "mysql:5.6",
+                    "ports": [
+                        {
+                            "name": "mysql",
+                            "containerPort": 3306,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "env": [
+                        {
+                            "name": "MYSQL_ROOT_PASSWORD",
+                            "value": "XXXXXX"
+                        }
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "mysql-persistent-storage",
+                            "mountPath": "/var/lib/mysql"
+                        },
+                        {
+                            "name": "kube-api-access-f9l29",
+                            "readOnly": true,
+                            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                        }
+                    ],
+                    "terminationMessagePath": "/dev/termination-log",
+                    "terminationMessagePolicy": "File",
+                    "imagePullPolicy": "IfNotPresent"
+                }
+            ],
+            "dnsPolicy": "ClusterFirst",
+            "enableServiceLinks": true,
+            "nodeName": "minikube",
+            "preemptionPolicy": "PreemptLowerPriority",
+            "priority": 0,
+            "restartPolicy": "Always",
+            "schedulerName": "default-scheduler",
+            "securityContext": {},
+            "serviceAccount": "default",
+            "serviceAccountName": "default",
+            "terminationGracePeriodSeconds": 30,
+            "tolerations": [
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300
+                }
+            ],
+            "volumes": [
+                {
+                    "emptyDir": {
+                        "sizeLimit": "1Gi"
+                    },
+                    "name": "mysql-persistent-storage"
+                },
+                {
+                    "name": "kube-api-access-f9l29",
+                    "projected": {
+                        "defaultMode": 420,
+                        "sources": [
+                            {
+                                "serviceAccountToken": {
+                                    "expirationSeconds": 3607,
+                                    "path": "token"
+                                }
+                            },
+                            {
+                                "configMap": {
+                                    "items": [
+                                        {
+                                            "key": "ca.crt",
+                                            "path": "ca.crt"
+                                        }
+                                    ],
+                                    "name": "kube-root-ca.crt"
+                                }
+                            },
+                            {
+                                "downwardAPI": {
+                                    "items": [
+                                        {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            },
+                                            "path": "namespace"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+}

--- a/workloadinterface/testdata/workloadmethods/podmountwithvolume.json
+++ b/workloadinterface/testdata/workloadmethods/podmountwithvolume.json
@@ -1,0 +1,138 @@
+{
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "creationTimestamp": "2023-08-08T13:15:52Z",
+            "generateName": "mysql-8664b6d846-",
+            "labels": {
+                "app": "mysql",
+                "pod-template-hash": "8664b6d846"
+            },
+            "name": "mysql-8664b6d846-zfwhm",
+            "namespace": "default",
+            "ownerReferences": [
+                {
+                    "apiVersion": "apps/v1",
+                    "blockOwnerDeletion": true,
+                    "controller": true,
+                    "kind": "ReplicaSet",
+                    "name": "mysql-8664b6d846",
+                    "uid": "617a9d8f-4344-4db7-a92d-1938091f0eb4"
+                }
+            ],
+            "resourceVersion": "973",
+            "uid": "f8d132f1-7fc0-44ff-ae3f-39bf5622876e"
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name": "mysql",
+                    "image": "mysql:5.6",
+                    "ports": [
+                        {
+                            "name": "mysql",
+                            "containerPort": 3306,
+                            "protocol": "TCP"
+                        }
+                    ],
+                    "env": [
+                        {
+                            "name": "MYSQL_ROOT_PASSWORD",
+                            "value": "XXXXXX"
+                        }
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "mysql-persistent-storage",
+                            "mountPath": "/var/lib/mysql"
+                        },
+                        {
+                            "name": "kube-api-access-f9l29",
+                            "readOnly": true,
+                            "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+                        }
+                    ],
+                    "terminationMessagePath": "/dev/termination-log",
+                    "terminationMessagePolicy": "File",
+                    "imagePullPolicy": "IfNotPresent"
+                }
+            ],
+            "dnsPolicy": "ClusterFirst",
+            "enableServiceLinks": true,
+            "nodeName": "minikube",
+            "preemptionPolicy": "PreemptLowerPriority",
+            "priority": 0,
+            "restartPolicy": "Always",
+            "schedulerName": "default-scheduler",
+            "securityContext": {},
+            "serviceAccount": "default",
+            "serviceAccountName": "default",
+            "terminationGracePeriodSeconds": 30,
+            "tolerations": [
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/not-ready",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300
+                },
+                {
+                    "effect": "NoExecute",
+                    "key": "node.kubernetes.io/unreachable",
+                    "operator": "Exists",
+                    "tolerationSeconds": 300
+                }
+            ],
+            "volumes": [
+                {
+                    "emptyDir": {
+                        "sizeLimit": "1Gi"
+                    },
+                    "name": "mysql-persistent-storage",
+                    "hostPath": {
+                        "path": "/var/lib/storage",
+                        "type": "Storage"
+                    }
+                },
+                {
+                    "name": "kube-api-access-f9l29",
+                    "projected": {
+                        "defaultMode": 420,
+                        "sources": [
+                            {
+                                "serviceAccountToken": {
+                                    "expirationSeconds": 3607,
+                                    "path": "token"
+                                }
+                            },
+                            {
+                                "configMap": {
+                                    "items": [
+                                        {
+                                            "key": "ca.crt",
+                                            "path": "ca.crt"
+                                        }
+                                    ],
+                                    "name": "kube-root-ca.crt"
+                                }
+                            },
+                            {
+                                "downwardAPI": {
+                                    "items": [
+                                        {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            },
+                                            "path": "namespace"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+}

--- a/workloadinterface/workloadmethods.go
+++ b/workloadinterface/workloadmethods.go
@@ -402,23 +402,6 @@ func (w *Workload) GetAnnotations() map[string]string {
 	return nil
 }
 
-// GetVolumes -
-func (w *Workload) GetVolumes() ([]corev1.Volume, error) {
-	volumes := []corev1.Volume{}
-
-	interVolumes, _ := InspectWorkload(w.workload, append(PodSpec(w.GetKind()), "volumes")...)
-	if interVolumes == nil {
-		return volumes, nil
-	}
-	volumesBytes, err := json.Marshal(interVolumes)
-	if err != nil {
-		return volumes, err
-	}
-	err = json.Unmarshal(volumesBytes, &volumes)
-
-	return volumes, err
-}
-
 func (w *Workload) GetServiceAccountName() string {
 
 	if v, ok := InspectWorkload(w.workload, append(PodSpec(w.GetKind()), "serviceAccountName")...); ok && v != nil {
@@ -695,20 +678,13 @@ func (w *Workload) GetPodStatus() (*corev1.PodStatus, error) {
 }
 
 // GetHostVolumes returns all host volumes of the workload
-func (w *Workload) GetHostVolumes() ([]v1.Volume, error) {
+func (w *Workload) GetVolumes() ([]v1.Volume, error) {
 	podSpec, err := w.GetPodSpec()
 	if err != nil {
 		return nil, err
 	}
 
-	var hostVolumes []v1.Volume
-	for _, volume := range podSpec.Volumes {
-		if volume.HostPath != nil {
-			hostVolumes = append(hostVolumes, volume)
-		}
-	}
-
-	return hostVolumes, nil
+	return podSpec.Volumes, nil
 }
 
 // GetSpecPathPrefix returns the path prefix of the workload spec

--- a/workloadinterface/workloadmethods.go
+++ b/workloadinterface/workloadmethods.go
@@ -19,12 +19,6 @@ import (
 
 const TypeWorkloadObject ObjectType = "workload"
 
-type VolumeMount struct {
-	ContainerIdx    int
-	VolumeMountIdx  int
-	VolumeMountPath string
-}
-
 type Workload struct {
 	workload map[string]interface{}
 }
@@ -700,52 +694,6 @@ func (w *Workload) GetPodStatus() (*corev1.PodStatus, error) {
 	return &status, nil
 }
 
-// GetVolumeMountsPaths returns all volume mounts paths of the workload
-// if readOnly is nil, returns all volume mounts paths
-// if readOnly is true, returns only readOnly volume mounts paths
-// if readOnly is false, returns only readWrite volume mounts paths
-// if mustHaveHostVolume is true, returns only volume mounts paths that have host volume
-func (w *Workload) GetVolumeMountsPaths(readOnly *bool, mustHaveHostVolume bool) ([]VolumeMount, error) {
-	podSpec, err := w.GetPodSpec()
-	if err != nil {
-		return nil, err
-	}
-
-	var hostVolumeNames []string
-
-	if mustHaveHostVolume {
-		hostVolumes, err := w.GetHostVolumes()
-		if err != nil {
-			return nil, err
-		}
-
-		for _, hostVolume := range hostVolumes {
-			hostVolumeNames = append(hostVolumeNames, hostVolume.Name)
-		}
-	}
-
-	var volumeMounts []VolumeMount
-	for i, container := range podSpec.Containers {
-		if len(container.VolumeMounts) > 0 {
-			for j, volumeMount := range container.VolumeMounts {
-				if readOnly == nil || volumeMount.ReadOnly == *readOnly {
-					if !mustHaveHostVolume || (mustHaveHostVolume && slices.Contains(hostVolumeNames, volumeMount.Name)) {
-						volumeMounts = append(volumeMounts, VolumeMount{
-							ContainerIdx:    i,
-							VolumeMountIdx:  j,
-							VolumeMountPath: volumeMount.MountPath,
-						})
-					}
-				}
-			}
-		}
-
-	}
-
-	return volumeMounts, nil
-
-}
-
 // GetHostVolumes returns all host volumes of the workload
 func (w *Workload) GetHostVolumes() ([]v1.Volume, error) {
 	podSpec, err := w.GetPodSpec()
@@ -764,7 +712,7 @@ func (w *Workload) GetHostVolumes() ([]v1.Volume, error) {
 }
 
 // GetSpecPathPrefix returns the path prefix of the workload spec
-func (w *Workload) GetSpecPathPrefix() (string, error) {
+func (w *Workload) GetSpecPath() (string, error) {
 	switch w.GetKind() {
 	case "Pod":
 		return "spec", nil

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -6,6 +6,7 @@ import (
 
 	_ "embed"
 
+	"github.com/armosec/utils-go/boolutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,6 +52,12 @@ var (
 
 	//go:embed testdata/workloadmethods/deploymentWithemptyLabels.json
 	deploymentWithemptyLabels string
+
+	//go:embed testdata/workloadmethods/podmountwithvolume.json
+	podMountWithVolume string
+
+	//go:embed testdata/workloadmethods/podmountnohostvolume.json
+	podMountNoHostVolume string
 
 	mockDeployment = `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1"},"creationTimestamp":"2021-05-03T13:10:32Z","generation":1,"managedFields":[{"apiVersion":"apps/v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:app":{},"f:cyberarmor.inject":{}}},"f:spec":{"f:progressDeadlineSeconds":{},"f:replicas":{},"f:revisionHistoryLimit":{},"f:selector":{},"f:strategy":{"f:rollingUpdate":{".":{},"f:maxSurge":{},"f:maxUnavailable":{}},"f:type":{}},"f:template":{"f:metadata":{"f:labels":{".":{},"f:app":{}}},"f:spec":{"f:containers":{"k:{\"name\":\"demoservice\"}":{".":{},"f:env":{".":{},"k:{\"name\":\"ARMO_TEST_NAME\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"CAA_ENABLE_CRASH_REPORTER\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"DEMO_FOLDERS\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"SERVER_PORT\"}":{".":{},"f:name":{},"f:value":{}},"k:{\"name\":\"SLEEP_DURATION\"}":{".":{},"f:name":{},"f:value":{}}},"f:image":{},"f:imagePullPolicy":{},"f:name":{},"f:ports":{".":{},"k:{\"containerPort\":8089,\"protocol\":\"TCP\"}":{".":{},"f:containerPort":{},"f:protocol":{}}},"f:resources":{},"f:terminationMessagePath":{},"f:terminationMessagePolicy":{}}},"f:dnsPolicy":{},"f:restartPolicy":{},"f:schedulerName":{},"f:securityContext":{},"f:terminationGracePeriodSeconds":{}}}}},"manager":"OpenAPI-Generator","operation":"Update","time":"2021-05-03T13:10:32Z"},{"apiVersion":"apps/v1","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:deployment.kubernetes.io/revision":{}}},"f:status":{"f:availableReplicas":{},"f:conditions":{".":{},"k:{\"type\":\"Available\"}":{".":{},"f:lastTransitionTime":{},"f:lastUpdateTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}},"k:{\"type\":\"Progressing\"}":{".":{},"f:lastTransitionTime":{},"f:lastUpdateTime":{},"f:message":{},"f:reason":{},"f:status":{},"f:type":{}}},"f:observedGeneration":{},"f:readyReplicas":{},"f:replicas":{},"f:updatedReplicas":{}}},"manager":"kube-controller-manager","operation":"Update","time":"2021-05-03T13:52:58Z"}],"name":"demoservice-server","namespace":"default","resourceVersion":"1016043","uid":"e9e8a3e9-6cb4-4301-ace1-2c0cef3bd61e"},"spec":{"progressDeadlineSeconds":600,"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app":"demoservice-server"}},"strategy":{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"demoservice-server"}},"spec":{"containers":[{"env":[{"name":"SERVER_PORT","value":"8089"},{"name":"SLEEP_DURATION","value":"1"},{"name":"DEMO_FOLDERS","value":"/app"},{"name":"ARMO_TEST_NAME","value":"auto_attach_deployment"},{"name":"CAA_ENABLE_CRASH_REPORTER","value":"1"}],"image":"quay.io/armosec/demoservice:v25","imagePullPolicy":"IfNotPresent","name":"demoservice","ports":[{"containerPort":8089,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File"}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30}}},"status":{"availableReplicas":1,"conditions":[{"lastTransitionTime":"2021-05-03T13:10:32Z","lastUpdateTime":"2021-05-03T13:10:37Z","message":"ReplicaSet \"demoservice-server-7d478b6998\" has successfully progressed.","reason":"NewReplicaSetAvailable","status":"True","type":"Progressing"},{"lastTransitionTime":"2021-05-03T13:52:58Z","lastUpdateTime":"2021-05-03T13:52:58Z","message":"Deployment has minimum availability.","reason":"MinimumReplicasAvailable","status":"True","type":"Available"}],"observedGeneration":1,"readyReplicas":1,"replicas":1,"updatedReplicas":1}}`
 	mockService    = `{"apiVersion":"v1","kind":"Service","metadata":{"creationTimestamp":"2021-12-06T14:01:16Z","labels":{"app":"armo-vuln-scan","app.kubernetes.io\/managed-by":"Helm"},"name":"armo-vuln-scan","resourceVersion":"351796","uid":"12bd4f9f-3ec6-4113-8ec6-0b8a1c772deb"},"spec":{"clusterIP":"10.107.7.78","clusterIPs":["10.107.7.78"],"internalTrafficPolicy":"Cluster","ipFamilies":["IPv4"],"ipFamilyPolicy":"SingleStack","ports":[{"port":8080,"protocol":"TCP","targetPort":8080}],"selector":{"app":"armo-vuln-scan"},"sessionAffinity":"None","type":"ClusterIP"},"status":{"loadBalancer":{}}}`
@@ -527,5 +534,144 @@ func TestGetLabels(t *testing.T) {
 			assert.Equal(t, tc.want, labels)
 		})
 	}
+
+}
+
+func TestGetSpecPathPrefix(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		mockData string
+		want     string
+	}{
+		{
+			name:     "deployment",
+			mockData: secretAndConfigMapForContainerDeployment,
+			want:     "spec.template.spec",
+		},
+		{
+			name:     "cronjob",
+			mockData: secretAndConfigMapForContainerCronjob,
+			want:     "spec.jobTemplate.spec.template.spec",
+		},
+		{
+			name:     "pod",
+			mockData: podStatusRunning,
+			want:     "spec",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workload, err := NewWorkload([]byte(tc.mockData))
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			path, err := workload.GetSpecPathPrefix()
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			assert.Equal(t, tc.want, path)
+		})
+	}
+
+}
+
+func TestGetVolumeMountsPaths(t *testing.T) {
+
+	tests := []struct {
+		name                 string
+		mockData             string
+		readOnly             *bool
+		mustHaveHostVolume   bool
+		expectedVolumesCount int
+	}{
+		{
+			name:                 "readonly true, mustHaveHostVolume true",
+			mockData:             podMountWithVolume,
+			readOnly:             boolutils.BoolPointer(true),
+			mustHaveHostVolume:   true,
+			expectedVolumesCount: 0,
+		},
+		{
+			name:                 "readonly true, mustHaveHostVolume false",
+			mockData:             podMountWithVolume,
+			readOnly:             boolutils.BoolPointer(true),
+			mustHaveHostVolume:   false,
+			expectedVolumesCount: 1,
+		},
+		{
+			name:                 "readonly false, mustHaveHostVolume true",
+			mockData:             podMountWithVolume,
+			readOnly:             boolutils.BoolPointer(false),
+			mustHaveHostVolume:   true,
+			expectedVolumesCount: 1,
+		},
+		{
+			name:                 "readonly false, mustHaveHostVolume false",
+			mockData:             podMountWithVolume,
+			readOnly:             boolutils.BoolPointer(false),
+			mustHaveHostVolume:   false,
+			expectedVolumesCount: 1,
+		},
+		{
+			name:                 "readonly nil, mustHaveHostVolume false",
+			mockData:             podMountWithVolume,
+			readOnly:             nil,
+			mustHaveHostVolume:   false,
+			expectedVolumesCount: 2,
+		},
+		{
+			name:                 "readonly nil, mustHaveHostVolume true",
+			mockData:             podMountWithVolume,
+			readOnly:             nil,
+			mustHaveHostVolume:   true,
+			expectedVolumesCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workload, err := NewWorkload([]byte(tc.mockData))
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			volumeMountPaths, err := workload.GetVolumeMountsPaths(tc.readOnly, tc.mustHaveHostVolume)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			assert.Equal(t, tc.expectedVolumesCount, len(volumeMountPaths), "test name: %s", tc.name)
+		})
+	}
+
+}
+
+func TestGetHostVolumes(t *testing.T) {
+	workload, err := NewWorkload([]byte(podMountWithVolume))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	hostVolumes, err := workload.GetHostVolumes()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	assert.Equal(t, 1, len(hostVolumes))
+
+	workload, err = NewWorkload([]byte(podMountNoHostVolume))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	hostVolumes, err = workload.GetHostVolumes()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	assert.Equal(t, 0, len(hostVolumes))
 
 }

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -52,8 +52,8 @@ var (
 	//go:embed testdata/workloadmethods/deploymentWithemptyLabels.json
 	deploymentWithemptyLabels string
 
-	// //go:embed testdata/workloadmethods/podmountwithvolume.json
-	// podMountWithVolume string
+	//go:embed testdata/workloadmethods/podmountwithvolume.json
+	podMountWithVolume string
 
 	//go:embed testdata/workloadmethods/podmountnohostvolume.json
 	podMountNoHostVolume string

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -6,7 +6,6 @@ import (
 
 	_ "embed"
 
-	"github.com/armosec/utils-go/boolutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,8 +52,8 @@ var (
 	//go:embed testdata/workloadmethods/deploymentWithemptyLabels.json
 	deploymentWithemptyLabels string
 
-	//go:embed testdata/workloadmethods/podmountwithvolume.json
-	podMountWithVolume string
+	// //go:embed testdata/workloadmethods/podmountwithvolume.json
+	// podMountWithVolume string
 
 	//go:embed testdata/workloadmethods/podmountnohostvolume.json
 	podMountNoHostVolume string
@@ -537,7 +536,7 @@ func TestGetLabels(t *testing.T) {
 
 }
 
-func TestGetSpecPathPrefix(t *testing.T) {
+func TestGetSpecPath(t *testing.T) {
 
 	tests := []struct {
 		name     string
@@ -568,82 +567,11 @@ func TestGetSpecPathPrefix(t *testing.T) {
 				t.Errorf(err.Error())
 			}
 
-			path, err := workload.GetSpecPathPrefix()
+			path, err := workload.GetSpecPath()
 			if err != nil {
 				t.Errorf(err.Error())
 			}
 			assert.Equal(t, tc.want, path)
-		})
-	}
-
-}
-
-func TestGetVolumeMountsPaths(t *testing.T) {
-
-	tests := []struct {
-		name                 string
-		mockData             string
-		readOnly             *bool
-		mustHaveHostVolume   bool
-		expectedVolumesCount int
-	}{
-		{
-			name:                 "readonly true, mustHaveHostVolume true",
-			mockData:             podMountWithVolume,
-			readOnly:             boolutils.BoolPointer(true),
-			mustHaveHostVolume:   true,
-			expectedVolumesCount: 0,
-		},
-		{
-			name:                 "readonly true, mustHaveHostVolume false",
-			mockData:             podMountWithVolume,
-			readOnly:             boolutils.BoolPointer(true),
-			mustHaveHostVolume:   false,
-			expectedVolumesCount: 1,
-		},
-		{
-			name:                 "readonly false, mustHaveHostVolume true",
-			mockData:             podMountWithVolume,
-			readOnly:             boolutils.BoolPointer(false),
-			mustHaveHostVolume:   true,
-			expectedVolumesCount: 1,
-		},
-		{
-			name:                 "readonly false, mustHaveHostVolume false",
-			mockData:             podMountWithVolume,
-			readOnly:             boolutils.BoolPointer(false),
-			mustHaveHostVolume:   false,
-			expectedVolumesCount: 1,
-		},
-		{
-			name:                 "readonly nil, mustHaveHostVolume false",
-			mockData:             podMountWithVolume,
-			readOnly:             nil,
-			mustHaveHostVolume:   false,
-			expectedVolumesCount: 2,
-		},
-		{
-			name:                 "readonly nil, mustHaveHostVolume true",
-			mockData:             podMountWithVolume,
-			readOnly:             nil,
-			mustHaveHostVolume:   true,
-			expectedVolumesCount: 1,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			workload, err := NewWorkload([]byte(tc.mockData))
-			if err != nil {
-				t.Errorf(err.Error())
-			}
-
-			volumeMountPaths, err := workload.GetVolumeMountsPaths(tc.readOnly, tc.mustHaveHostVolume)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
-
-			assert.Equal(t, tc.expectedVolumesCount, len(volumeMountPaths), "test name: %s", tc.name)
 		})
 	}
 

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -577,29 +577,17 @@ func TestGetSpecPath(t *testing.T) {
 
 }
 
-func TestGetHostVolumes(t *testing.T) {
+func TestGetVolumes(t *testing.T) {
 	workload, err := NewWorkload([]byte(podMountWithVolume))
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	hostVolumes, err := workload.GetHostVolumes()
+	volumes, err := workload.GetVolumes()
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
-	assert.Equal(t, 1, len(hostVolumes))
-
-	workload, err = NewWorkload([]byte(podMountNoHostVolume))
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	hostVolumes, err = workload.GetHostVolumes()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-
-	assert.Equal(t, 0, len(hostVolumes))
+	assert.Equal(t, 2, len(volumes))
 
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces three new functions to the workload interface, aimed at providing more information about the volumes used in workloads. These functions are:
1. `GetVolumeMountsPaths`: Returns all volume mount paths of the workload, with options to filter by read-only status and whether the volume is a host volume.
2. `GetHostVolumes`: Returns all host volumes of the workload.
3. `GetSpecPathPrefix`: Returns the path prefix of the workload spec, depending on the kind of the workload.
The PR also includes relevant unit tests for these new functions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`workloadinterface/workloadmethods.go`: Added three new functions: `GetVolumeMountsPaths`, `GetHostVolumes`, and `GetSpecPathPrefix`. Also, added a new struct `VolumeMount` to represent a volume mount.
`workloadinterface/workloadmethods_test.go`: Added unit tests for the three new functions: `TestGetSpecPathPrefix`, `TestGetVolumeMountsPaths`, and `TestGetHostVolumes`.
`workloadinterface/testdata/workloadmethods/podmountnohostvolume.json`: Added a new test data file representing a pod with a volume mount that does not have a host volume.
`workloadinterface/testdata/workloadmethods/podmountwithvolume.json`: Added a new test data file representing a pod with a volume mount that has a host volume.
</details>

___
## User Description:
Added 3 functions to be used for smart remediation:
GetVolumeMountsPaths
GetHostVolumes
GetSpecPathPrefix
