### PR TITLE
support service selector

### DIFF
--- a/workloadinterface/interface.go
+++ b/workloadinterface/interface.go
@@ -61,6 +61,7 @@ type IBasicWorkload interface {
 	GetImagePullSecret() ([]corev1.LocalObjectReference, error)
 	GetServiceAccountName() string
 	GetSelector() (*metav1.LabelSelector, error)
+	GetServiceSelector() map[string]string
 	GetResourceVersion() string
 	GetUID() string
 	GetPodSpec() (*corev1.PodSpec, error)

--- a/workloadinterface/workloadmethods.go
+++ b/workloadinterface/workloadmethods.go
@@ -286,6 +286,18 @@ func (w *Workload) GetKind() string {
 	}
 	return ""
 }
+
+func (w *Workload) GetServiceSelector() map[string]string {
+	if v, ok := InspectWorkload(w.workload, "spec", "selector"); ok && v != nil {
+		selector := make(map[string]string)
+		for k, i := range v.(map[string]interface{}) {
+			selector[k] = fmt.Sprintf("%v", i)
+		}
+		return selector
+	}
+	return nil
+}
+
 func (w *Workload) GetSelector() (*metav1.LabelSelector, error) {
 	selector := &metav1.LabelSelector{}
 	if matchLabels, ok := InspectWorkload(w.workload, "spec", "selector", "matchLabels"); ok && matchLabels != nil {

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -90,6 +90,22 @@ func TestGetSelector(t *testing.T) {
 	assert.Equal(t, 1, len(l.MatchLabels))
 	assert.Equal(t, 0, len(l.MatchExpressions))
 }
+
+func TestGetServiceSelector(t *testing.T) {
+	workload, err := NewWorkload([]byte(mockService))
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	s := workload.GetServiceSelector()
+	expected := map[string]string{
+		"app": "armo-vuln-scan",
+	}
+
+	assert.Equal(t, expected, s)
+
+}
+
 func TestSetNamespace(t *testing.T) {
 	w := `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"demoservice-server"},"spec":{"replicas":1,"selector":{"matchLabels":{"app":"demoservice-server"}},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"demoservice-server"}},"spec":{"containers":[{"env":[{"name":"SERVER_PORT","value":"8089"},{"name":"SLEEP_DURATION","value":"1"},{"name":"DEMO_FOLDERS","value":"/app"},{"name":"ARMO_TEST_NAME","value":"auto_attach_deployment"},{"name":"CAA_ENABLE_CRASH_REPORTER","value":"1"}],"image":"quay.io/armosec/demoservice:v25","imagePullPolicy":"IfNotPresent","name":"demoservice","ports":[{"containerPort":8089,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File"}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30}}}}`
 	workload, err := NewWorkload([]byte(w))

--- a/workloadinterface/workloadmock.go
+++ b/workloadinterface/workloadmock.go
@@ -170,6 +170,10 @@ func (wm *WorkloadMock) GetSelector() (*metav1.LabelSelector, error) {
 	return wm.workload.GetSelector()
 }
 
+func (wm *WorkloadMock) GetServiceSelector() map[string]string {
+	return wm.workload.GetServiceSelector()
+}
+
 func (wm *WorkloadMock) GetAnnotation(annotation string) (string, bool) {
 	return wm.workload.GetAnnotation(annotation)
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new method to retrieve the selector from Service kind objects. The previous `GetSelector` function was not compatible with `Service` kind as the `selector` has a different type. The new method `GetServiceSelector` returns a map of strings, allowing it to work with the `Service` kind.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`workloadinterface/interface.go`: Added a new method `GetServiceSelector` to the `IBasicWorkload` interface.
`workloadinterface/workloadmethods.go`: Implemented the `GetServiceSelector` method in the `Workload` struct. This method inspects the workload and retrieves the service selector if it exists.
`workloadinterface/workloadmethods_test.go`: Added a new test `TestGetServiceSelector` to verify the correct functionality of the `GetServiceSelector` method.
`workloadinterface/workloadmock.go`: Added the `GetServiceSelector` method to the `WorkloadMock` struct to align with the updated interface.
</details>

___
## User Description:
Current `GetSelector` function doesn't work for `Service` kind, since the `selector` has a different type. This PR adds support for retrieving selectors from services as well
