### PR TITLE
add ResourceVersionMetadataKey for related wl version

### DIFF
--- a/instanceidhandler/v1/instanceidhandler.go
+++ b/instanceidhandler/v1/instanceidhandler.go
@@ -23,6 +23,7 @@ const (
 	KindMetadataKey                   = metadataPrefix + "/workload-kind"
 	NameMetadataKey                   = metadataPrefix + "/workload-name"
 	NamespaceMetadataKey              = metadataPrefix + "/workload-namespace"
+	ResourceVersionMetadataKey        = metadataPrefix + "/workload-resource-version"
 	StatusMetadataKey                 = metadataPrefix + "/status"
 	WlidMetadataKey                   = metadataPrefix + "/wlid"
 	ContextMetadataKey                = metadataPrefix + "/context"


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new constant, `ResourceVersionMetadataKey`, to the `instanceidhandler.go` file. This key is intended to be used for storing the workload resource version.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `instanceidhandler/v1/instanceidhandler.go`: Added a new constant `ResourceVersionMetadataKey` for storing the workload resource version.
</details>
