### PR TITLE
Revert "keep group/version together in apiVersion label"

### DIFF
--- a/instanceidhandler/v1/instanceidhandler.go
+++ b/instanceidhandler/v1/instanceidhandler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/kubescape/k8s-interface/instanceidhandler"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/names"
 )
 
@@ -119,8 +120,10 @@ func (id *InstanceID) GetHashed() string {
 }
 
 func (id *InstanceID) GetLabels() map[string]string {
+	group, version := k8sinterface.SplitApiVersion(id.GetAPIVersion())
 	return map[string]string{
-		ApiVersionMetadataKey:    id.GetAPIVersion(),
+		ApiGroupMetadataKey:      group,
+		ApiVersionMetadataKey:    version,
 		NamespaceMetadataKey:     id.GetNamespace(),
 		KindMetadataKey:          id.GetKind(),
 		NameMetadataKey:          id.GetName(),

--- a/instanceidhandler/v1/instanceidhandler_test.go
+++ b/instanceidhandler/v1/instanceidhandler_test.go
@@ -107,7 +107,8 @@ func TestInstanceID(t *testing.T) {
 		t.Errorf("can't create instance ID from service")
 	}
 	expectedLabels := map[string]string{
-		ApiVersionMetadataKey:    "apps/v1",
+		ApiGroupMetadataKey:      "apps",
+		ApiVersionMetadataKey:    "v1",
 		NamespaceMetadataKey:     "default",
 		KindMetadataKey:          "ReplicaSet",
 		NameMetadataKey:          "nginx-84f5585d68",
@@ -120,7 +121,8 @@ func TestInstanceID(t *testing.T) {
 	}
 
 	expectedLabels = map[string]string{
-		ApiVersionMetadataKey:    "batch/v1",
+		ApiGroupMetadataKey:      "batch",
+		ApiVersionMetadataKey:    "v1",
 		NamespaceMetadataKey:     "default",
 		KindMetadataKey:          "Job",
 		NameMetadataKey:          "nginx-job",
@@ -132,6 +134,7 @@ func TestInstanceID(t *testing.T) {
 	}
 
 	expectedLabels = map[string]string{
+		ApiGroupMetadataKey:      "",
 		ApiVersionMetadataKey:    "v1",
 		NamespaceMetadataKey:     "default",
 		KindMetadataKey:          "Pod",


### PR DESCRIPTION
## type:
bug_fix

___
## description:
This PR reverts a previous change that kept group/version together in the apiVersion label. The change was reverted due to compatibility issues with label naming. Now, the API group and version are split and stored separately in the metadata labels. This change affects both the main instance ID handler and its associated tests.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `instanceidhandler/v1/instanceidhandler.go`: The API group and version are now split using the `SplitApiVersion` function from the `k8sinterface` package. The group and version are then stored separately in the metadata labels.
- `instanceidhandler/v1/instanceidhandler_test.go`: The tests have been updated to reflect the changes in the main instance ID handler. The expected labels now include separate entries for the API group and version.
</details>

___
## User Description:
Reverts kubescape/k8s-interface#82
This change will break label naming compatibility.
