### PR TITLE
remove hash and ns from name

### DIFF
--- a/instanceidhandler/v1/instanceidhandler.go
+++ b/instanceidhandler/v1/instanceidhandler.go
@@ -132,5 +132,5 @@ func (id *InstanceID) GetLabels() map[string]string {
 }
 
 func (id *InstanceID) GetSlug() (string, error) {
-	return names.InstanceIDToSlug(id.GetName(), id.GetNamespace(), id.GetKind(), id.GetHashed())
+	return names.InstanceIDToSlug(id.GetName(), id.GetKind(), id.GetHashed())
 }

--- a/instanceidhandler/v1/instanceidhandler_test.go
+++ b/instanceidhandler/v1/instanceidhandler_test.go
@@ -164,7 +164,7 @@ func TestInstanceIDToDisplayName(t *testing.T) {
 				name:          "reverse-proxy",
 				containerName: "nginx",
 			},
-			want:    "default-pod-reverse-proxy-2f07-68bd",
+			want:    "pod-reverse-proxy",
 			wantErr: nil,
 		},
 		{
@@ -176,7 +176,7 @@ func TestInstanceIDToDisplayName(t *testing.T) {
 				name:          "webapp",
 				containerName: "leader",
 			},
-			want:    "default-service-webapp-cca3-8ea7",
+			want:    "service-webapp",
 			wantErr: nil,
 		},
 		{


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR focuses on changing the naming convention of slugs in the application. The main changes include:
- Removing the namespace and hash from the slug format.
- Updating the `GetSlug` method in `instanceidhandler.go` and its corresponding tests to reflect this change.
- Removing the `GetNamespaceLessSlug` method from `slugs.go`.
- Updating the `InstanceIDToSlug`, `sanitizeInstanceIDSlug`, `StringToSlug`, and `ResourceToSlug` methods in `slugs.go` and their corresponding tests to reflect these changes.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>instanceidhandler.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        instanceidhandler/v1/instanceidhandler.go<br><br>

**The `GetSlug` method has been updated to exclude the <br>namespace from the slug generation process.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/85/files#diff-3d8b023272f9dbd6a0fbf89d4b9d950778a7e31beacbf96c40fb8bc57ce38a4f"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>slugs.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        names/slugs.go<br><br>

**Several changes have been made to the slug generation and <br>sanitization methods. The namespace and hash have been <br>removed from the slug format. The `GetNamespaceLessSlug` <br>method has been removed. The `InstanceIDToSlug`, <br>`sanitizeInstanceIDSlug`, `StringToSlug`, and <br>`ResourceToSlug` methods have been updated to reflect these <br>changes.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/85/files#diff-c668b6d912dd9ca24caa1ee4cb37263bfc6389ac526f115b227a1e41eed0a1f7"> +12/-35</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>instanceidhandler_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        instanceidhandler/v1/instanceidhandler_test.go<br><br>

**The test cases for `TestInstanceIDToDisplayName` have been <br>updated to reflect the changes in the `GetSlug` method.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/85/files#diff-b8edce0ff94a0e658acb551309d6413fba052bf4a389f366d55f5c73435da601"> +2/-2</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>slugs_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        names/slugs_test.go<br><br>

**The test cases for `TestInstanceIDToFriendlyName`, <br>`TestStringToSlug`, `TestResourceToSlug`, and <br>`TestRoleBindingResourceToSlug` have been updated to reflect <br>the changes in the slug generation methods. The test cases <br>for `GetNamespaceLessSlug` have been removed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/85/files#diff-f897010a91f6df665669659914277f37c01a28dfcae5c4485005cd480552b1f0"> +12/-79</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>