### PR TITLE
adding TemplateHashKey

### DIFF
--- a/instanceidhandler/v1/instanceidhandler.go
+++ b/instanceidhandler/v1/instanceidhandler.go
@@ -20,6 +20,7 @@ const (
 	ImageTagMetadataKey               = metadataPrefix + "/image-tag"
 	ImageIDMetadataKey                = metadataPrefix + "/image-id"
 	InstanceIDMetadataKey             = metadataPrefix + "/instance-id"
+	TemplateHashKey                   = metadataPrefix + "/instance-template-hash"
 	KindMetadataKey                   = metadataPrefix + "/workload-kind"
 	NameMetadataKey                   = metadataPrefix + "/workload-name"
 	NamespaceMetadataKey              = metadataPrefix + "/workload-namespace"


### PR DESCRIPTION
## Type
enhancement


___

## Description
- Added a new constant `TemplateHashKey` to the metadata keys in `instanceidhandler.go`. This key will be used for instance template hash.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>instanceidhandler.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        instanceidhandler/v1/instanceidhandler.go<br><br>

**A new constant `TemplateHashKey` has been added to the list <br>of metadata keys.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/86/files#diff-3d8b023272f9dbd6a0fbf89d4b9d950778a7e31beacbf96c40fb8bc57ce38a4f"> +1/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>