### PR TITLE
generate replicaset from pod hash

### DIFF
--- a/workloadinterface/workloadmethodsutils.go
+++ b/workloadinterface/workloadmethodsutils.go
@@ -1,5 +1,10 @@
 package workloadinterface
 
+import (
+	"fmt"
+	"strings"
+)
+
 func PodSpec(kind string) []string {
 	switch kind {
 	case "Pod", "Namespace":
@@ -25,4 +30,25 @@ func PodMetadata(kind string) []string {
 // InspectWorkload - // DEPRECATED
 func InspectWorkload(workload interface{}, scopes ...string) (val interface{}, k bool) {
 	return InspectMap(workload, scopes...)
+}
+
+func getReplicasetNameFromPod(podName, podTemplateHash string) (string, error) {
+	// Example pod name: pod-name-123-456
+	// Example podTemplateHash: 123
+	// Return value: pod-name-123
+
+	// Extract the pod base name without the template hash.
+	i := strings.Index(podName, podTemplateHash)
+	if i == -1 || len(podName) <= i-1 {
+		return "", fmt.Errorf("failed to get replicaset name from pod name: %s", podName)
+	}
+	basePodName := podName[:i-1]
+
+	// Construct the replicaset name by appending the template hash.
+	replicasetName := fmt.Sprintf("%s-%s", basePodName, podTemplateHash)
+
+	if replicasetName == "" || replicasetName == podName {
+		return "", fmt.Errorf("failed to get replicaset name from pod name: %s", podName)
+	}
+	return replicasetName, nil
 }

--- a/workloadinterface/workloadmethodsutils_test.go
+++ b/workloadinterface/workloadmethodsutils_test.go
@@ -1,0 +1,54 @@
+package workloadinterface
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGetReplicasetNameFromPod(t *testing.T) {
+	tt := []struct {
+		podName         string
+		podTemplateHash string
+		want            string
+		wantErr         error
+	}{
+		{
+			podName:         "pod-name-123-456",
+			podTemplateHash: "123",
+			want:            "pod-name-123",
+			wantErr:         nil,
+		},
+		{
+			podName:         "pod-name-789-012",
+			podTemplateHash: "789",
+			want:            "pod-name-789",
+			wantErr:         nil,
+		},
+		{
+			podName:         "bla-pod-name-abc2236-def",
+			podTemplateHash: "abc2236",
+			want:            "bla-pod-name-abc2236",
+			wantErr:         nil,
+		},
+		{
+			podName:         "pod-name",
+			podTemplateHash: "123",
+			want:            "",
+			wantErr:         fmt.Errorf("failed to get replicaset name from pod name: pod-name"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(fmt.Sprintf("podName=%s, podTemplateHash=%s", tc.podName, tc.podTemplateHash), func(t *testing.T) {
+			got, err := getReplicasetNameFromPod(tc.podName, tc.podTemplateHash)
+
+			if got != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+
+			if (err != nil && tc.wantErr == nil) || (err == nil && tc.wantErr != nil) || (err != nil && tc.wantErr != nil && err.Error() != tc.wantErr.Error()) {
+				t.Errorf("got error %v, want error %v", err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Type
enhancement, tests


___

## Description
- Added a new functionality in `workloadinterface/workloadmethods.go` to handle the case where the workload is a Pod with a `pod-template-hash` label. In this case, it generates a `ReplicaSet` from the pod hash and appends it to the `ownerReferences`.
- Implemented a new function `getReplicasetNameFromPod` in `workloadinterface/workloadmethodsutils.go` that constructs a `ReplicaSet` name from a given pod name and pod template hash.
- Added unit tests in `workloadinterface/workloadmethodsutils_test.go` for the new function `getReplicasetNameFromPod` to validate its functionality.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>workloadmethods.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        workloadinterface/workloadmethods.go<br><br>

**Added a check in the `GetOwnerReferences` function to handle <br>the case where the workload is a Pod with a <br>`pod-template-hash` label. In this case, it generates a <br>`ReplicaSet` from the pod hash and appends it to the <br>`ownerReferences`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/88/files#diff-201cfee8d2d408c3bf28a9d1583c9439d91af935b97f2fd26ef080c91bdd1fc7"> +12/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>workloadmethodsutils.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        workloadinterface/workloadmethodsutils.go<br><br>

**Added a new function `getReplicasetNameFromPod` that <br>constructs a `ReplicaSet` name from a given pod name and pod <br>template hash. It also handles error scenarios where the <br>`ReplicaSet` name cannot be constructed.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/88/files#diff-b19c769c713ddc907602940a30699d2add8d6120554ade6bca16e50bf4c02a5a"> +26/-0</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>workloadmethodsutils_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        workloadinterface/workloadmethodsutils_test.go<br><br>

**Added unit tests for the new function <br>`getReplicasetNameFromPod` to validate its functionality <br>with different inputs and expected outputs.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/88/files#diff-40e8a3a39b6006895481ee2d1624537d4eba356dbc1e98c1d5574fd07446e171"> +54/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>