### PR TITLE
Fixed parse eks region

### DIFF
--- a/cloudsupport/v1/ekssupport.go
+++ b/cloudsupport/v1/ekssupport.go
@@ -125,8 +125,10 @@ func (eksSupport *EKSSupport) GetRegion(cluster string) (string, error) {
 			splittedClusterContext := strings.Split(cluster, "-")
 			if len(splittedClusterContext) < 4 {
 				return "", fmt.Errorf("failed to get region")
-			} else {
+			} else if len(splittedClusterContext) >= 6 {
 				return strings.Join(splittedClusterContext[3:6], "-"), nil
+			} else {
+				return "", fmt.Errorf("failed to get region")
 			}
 		}
 		region = splittedClusterContext[3]

--- a/cloudsupport/v1/ekssupport_test.go
+++ b/cloudsupport/v1/ekssupport_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -27,14 +28,60 @@ func TestGetContextName(t *testing.T) {
 }
 
 func TestGetRegion(t *testing.T) {
-	mockname1 := "arn:aws:eks:eu-north-1:123456789:cluster-test-cluster"
-	eksSupport := NewEKSSupport()
-	region, err := eksSupport.GetRegion(mockname1)
-	assert.NoError(t, err)
-	assert.Equal(t, "eu-north-1", region)
+	tests := []struct {
+		name           string
+		cluster        string
+		envRegion      string
+		expectedRegion string
+		expectErr      bool
+	}{
+		{
+			name:           "Region is extracted from cluster name 1",
+			cluster:        "arn:aws:eks:eu-north-1:123456789:cluster-test-cluster",
+			expectedRegion: "eu-north-1",
+			expectErr:      false,
+		},
+		{
+			name:           "Region is extracted from cluster name 2",
+			cluster:        "arn-aws-eks-eu-west-2-XXXXXXXXXXXX-cluster-Yiscah-test-g2am5",
+			expectedRegion: "eu-west-2",
+			expectErr:      false,
+		},
+		{
+			name:           "Region is present in environment variable",
+			envRegion:      "us-west-2",
+			expectedRegion: "us-west-2",
+			expectErr:      false,
+		},
+		{
+			name:           "Region is extracted from cluster name with ':' separator",
+			cluster:        "cluster:us-west-2:eks",
+			expectedRegion: "us-west-2",
+			expectErr:      true,
+		},
+		{
+			name:      "Failed to get region",
+			cluster:   "cluster",
+			expectErr: true,
+		},
+	}
 
-	mockname2 := "arn-aws-eks-eu-west-2-XXXXXXXXXXXX-cluster-Yiscah-test-g2am5"
-	region, err = eksSupport.GetRegion(mockname2)
-	assert.NoError(t, err)
-	assert.Equal(t, "eu-west-2", region)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envRegion != "" {
+				os.Setenv(KS_CLOUD_REGION_ENV_VAR, tt.envRegion)
+				defer os.Unsetenv(KS_CLOUD_REGION_ENV_VAR)
+			}
+
+			eksSupport := &EKSSupport{}
+			region, err := eksSupport.GetRegion(tt.cluster)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedRegion, region)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## **User description**
Here is the error log:
```
{"level":"info","ts":"2024-02-06T13:36:52Z","msg":"credentials loaded from path","path":"/etc/credentials","accessKeyLength":36,"accountLength":36}
{"level":"info","ts":"2024-02-06T13:36:52Z","msg":"Starting swagger UI. baseURI: /openapi/v2/, docsEP: docs, rapidocEP: rapi, swaggerui: swaggerui"}
{"level":"info","ts":"2024-02-06T13:36:52Z","msg":"Started Kubescape server","port":"8080","version":""}
{"level":"info","ts":"2024-02-06T13:37:01Z","msg":"REST API received scan request","body":"{\"targetNames\":[\"allcontrols\",\"nsa\",\"mitre\",\"security\"],\"targetType\":\"Framework\",\"hostScanner\":false}"}
{"level":"info","ts":"2024-02-06T13:37:01Z","msg":"requesting scan","scanID":"9bf77782-58c5-4be4-8736-96f81ba1e471","api":"v1/scan"}
{"level":"info","ts":"2024-02-06T13:37:01Z","msg":"triggering scan","scanID":"9bf77782-58c5-4be4-8736-96f81ba1e471"}
{"level":"info","ts":"2024-02-06T13:37:01Z","msg":"scan triggered","ID":"9bf77782-58c5-4be4-8736-96f81ba1e471"}
{"level":"info","ts":"2024-02-06T13:37:01Z","msg":"Kubescape scanner initializing..."}
I0206 13:37:03.391816       1 request.go:696] Waited for 1.047025452s due to client-side throttling, not priority and fairness, request: GET:https://172.20.0.1:443/apis/storage.k8s.io/v1beta1?timeout=32s
{"level":"warn","ts":"2024-02-06T13:37:04Z","msg":"Unknown build number: this might affect your scan results. Please ensure that you are running the latest version."}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Initialized scanner"}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Loading policies..."}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Loaded policies"}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Loading exceptions..."}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Loaded exceptions"}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Loading account configurations..."}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Loaded account configurations"}
{"level":"info","ts":"2024-02-06T13:37:06Z","msg":"Accessing Kubernetes objects..."}
{"level":"info","ts":"2024-02-06T13:37:11Z","msg":"Accessed Kubernetes objects"}
{"level":"info","ts":"2024-02-06T13:37:11Z","msg":"Collecting RBAC resources..."}
{"level":"info","ts":"2024-02-06T13:37:15Z","msg":"Collected RBAC resources"}
{"level":"info","ts":"2024-02-06T13:37:15Z","msg":"Downloading cloud resources..."}
panic: runtime error: slice bounds out of range [:6] with capacity 4 [recovered]
	panic: runtime error: slice bounds out of range [:6] with capacity 4 [recovered]
	panic: runtime error: slice bounds out of range [:6] with capacity 4

goroutine 42 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.18.0/trace/span.go:383 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc001312000, {0x0, 0x0, 0xcbdca2e176faa27e?})
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.18.0/trace/span.go:421 +0x9fb
panic({0x3d38b00?, 0xc004a14ff0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.func1()
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.18.0/trace/span.go:383 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc000da0600, {0x0, 0x0, 0xc00456ae08?})
	/go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.18.0/trace/span.go:421 +0x9fb
panic({0x3d38b00?, 0xc004a14ff0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/kubescape/k8s-interface/cloudsupport/v1.(*EKSSupport).GetRegion(0xc0006e41c0?, {0xc0011dac00, 0x15})
	/go/pkg/mod/github.com/kubescape/k8s-interface@v0.0.156/cloudsupport/v1/ekssupport.go:129 +0x14e
github.com/kubescape/k8s-interface/cloudsupport.GetDescriptiveInfoFromCloudProvider({0xc0011dac00, 0x15}, {0x3fa369e?, 0xc004a48ed0?})
	/go/pkg/mod/github.com/kubescape/k8s-interface@v0.0.156/cloudsupport/cloudproviderconfiguration.go:52 +0xf2
github.com/kubescape/kubescape/v3/core/pkg/resourcehandler.(*K8sResourceHandler).collectCloudResources(0xc001a68fc0, {0x4c3bd30, 0xc0020f2b10}, 0xc0000f6960, 0xc002183b70?, 0x3d84540?, {0xc0097456c0, 0x3, 0xc0000a8800?}, {0x4c2b600, ...})
	/work/core/pkg/resourcehandler/k8sresources.go:229 +0x574
github.com/kubescape/kubescape/v3/core/pkg/resourcehandler.(*K8sResourceHandler).GetResources(0xc001a68fc0, {0x4c3bd30, 0xc0020f2b10}, 0xc0000f6960, {0x4c2b600, 0xc001895f38}, 0xc0014d4480)
	/work/core/pkg/resourcehandler/k8sresources.go:146 +0xb39
github.com/kubescape/kubescape/v3/core/pkg/resourcehandler.CollectResources({0x4c3bd30, 0xc0020f2ae0}, {0x4c2b570, 0xc001a68fc0}, {0x0?, 0xc0010b9f01?, 0xc000eca500?}, 0xc0000f6960, {0x4c2b600, 0xc001895f38}, ...)
	/work/core/pkg/resourcehandler/handlerpullresources.go:29 +0x1b5
github.com/kubescape/kubescape/v3/core/core.(*Kubescape).Scan(0xc0010c2440?, {0x4c3bd30?, 0xc0010a62a0}, 0xc0014d4480)
	/work/core/core/scan.go:166 +0x825
github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.scan({0x4c3bd30, 0xc00163b3e0}, 0xc0014d4480, {0xc00012e7b0, 0x24})
	/work/httphandler/handlerequests/v1/requestshandlerutils.go:76 +0xf85
github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.(*HTTPHandler).executeScan(0xc000f7f320, 0xc00163af00)
	/work/httphandler/handlerequests/v1/requestshandlerutils.go:31 +0x16a
github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.(*HTTPHandler).watchForScan(0xc000f7f320)
	/work/httphandler/handlerequests/v1/requestshandlerutils.go:56 +0x53
created by github.com/kubescape/kubescape/v3/httphandler/handlerequests/v1.NewHTTPHandler in goroutine 1
	/work/httphandler/handlerequests/v1/requestshandler.go:44 +0x12f
```


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Enhanced the logic for parsing the AWS region from EKS cluster names, supporting a wider range of cluster name formats.
- Improved error handling in cases where the region cannot be determined from the cluster name.
- Added comprehensive test cases to validate the parsing of AWS regions from various EKS cluster name formats, including handling of environment variables.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ekssupport.go</strong><dd><code>Enhanced EKS Region Parsing Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cloudsupport/v1/ekssupport.go
<li>Improved logic for extracting region from EKS cluster name.<br> <li> Added support for cluster names with different formats.<br> <li> Enhanced error handling for cases where the region cannot be <br>determined.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/92/files#diff-f103e13bd94e46af384a6f1beaedc908e6525edd2efe500125cd27af1b8f5df8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ekssupport_test.go</strong><dd><code>Comprehensive Tests for EKS Region Parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cloudsupport/v1/ekssupport_test.go
<li>Introduced comprehensive test cases for EKS region parsing.<br> <li> Added support for setting region via environment variable in tests.<br> <li> Improved test structure for better clarity and coverage.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/92/files#diff-2b6b708c518fe857801a042b4fe21c22b322cbf44c5394258c6b7e39ef2f7d17">+56/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

