### PR TITLE
adding new consts for KDR feature

### DIFF
--- a/instanceidhandler/v1/helpers/keys.go
+++ b/instanceidhandler/v1/helpers/keys.go
@@ -30,6 +30,8 @@ const (
 	RoleBindingNamespaceMetadataKey   = metadataPrefix + "/rolebinding-namespace"
 	ClusterRoleNameMetadataKey        = metadataPrefix + "/clusterrole-name"
 	ClusterRoleBindingNameMetadataKey = metadataPrefix + "/clusterrolebinding-name"
+	ResourceSizeMetadataKey           = metadataPrefix + "/resource-size"
+	CompletionMetadataKey             = metadataPrefix + "/completion"
 )
 
 // metadata values
@@ -49,11 +51,19 @@ const (
 
 // Statuses
 const (
-	Initializing = "initializing"
-	Ready        = "ready"
-	Completed    = "completed"
-	Incomplete   = "incomplete"
-	Unauthorize  = "unauthorize"
+	Initializing   = "initializing"
+	Ready          = "ready"
+	Completed      = "completed"
+	Incomplete     = "incomplete"
+	Unauthorize    = "unauthorize"
+	MissingRuntime = "missing-runtime"
+	TooLarge       = "too-large"
+)
+
+// Completion
+const (
+	Partial  = "partial"
+	Complete = "complete"
 )
 
 func IgnoreOwnerReference(ownerKind string) bool {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new metadata key `ResourceSizeMetadataKey` to track the size of resources.
- Added new statuses (`Partial`, `Full`, `MissingRuntime`, `TooLarge`) to provide more detailed information about the state of resources.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>keys.go</strong><dd><code>Add Resource Size Metadata Key and New Status Constants</code>&nbsp; &nbsp; </dd></summary>
<hr>

instanceidhandler/v1/helpers/keys.go
<li>Added <code>ResourceSizeMetadataKey</code> constant for tracking resource size.<br> <li> Introduced new statuses: <code>Partial</code>, <code>Full</code>, <code>MissingRuntime</code>, and <code>TooLarge</code> <br>to better describe the state of resources.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/k8s-interface/pull/94/files#diff-20048b1967b23ee1ff0c59347cf72c1eb736e6c10ef31c93bad3bfa9ab545004">+10/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

