### PR TITLE
fix(cloudsupport): make AKS cloud-describe with timeout

### DIFF
--- a/cloudsupport/cloudproviderconfiguration.go
+++ b/cloudsupport/cloudproviderconfiguration.go
@@ -1,6 +1,7 @@
 package cloudsupport
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -16,7 +17,21 @@ const (
 	TypeCloudProviderDescription workloadinterface.ObjectType = "CloudProviderDescribe" // DEPRECATED
 	CloudProviderDescriptionKind                              = "ClusterDescription"    // DEPRECATED
 	KS_KUBE_CLUSTER_ENV_VAR                                   = "KS_KUBE_CLUSTER"
+	KS_OFFLINE_ENV_VAR                                        = "KS_OFFLINE"
 )
+
+// ErrCloudDescribeUnavailable is returned by the Get*FromCloudProvider entry
+// points when cluster cloud-describe data cannot be obtained but the failure
+// must not abort the scan (e.g. air-gapped environments, missing creds, or
+// KS_OFFLINE=true). Callers should recognise it via errors.Is and continue
+// collecting the remaining host-scanner / node-agent data.
+var ErrCloudDescribeUnavailable = errors.New("cloud describe unavailable")
+
+// cloudDescribeDisabled reports whether cloud-describe should be skipped
+// entirely. Set by the Helm chart when capabilities.kubescapeOffline=enable.
+func cloudDescribeDisabled() bool {
+	return os.Getenv(KS_OFFLINE_ENV_VAR) == "true"
+}
 
 func IsRunningInCloudProvider(cluster string) bool {
 	if cluster == "" {
@@ -44,6 +59,10 @@ func GetCloudProvider(nodeList *corev1.NodeList) string {
 
 // GetDescriptiveInfoFromCloudProvider returns the cluster description from the cloud provider wrapped in IMetadata obj
 func GetDescriptiveInfoFromCloudProvider(cluster string, cloudProvider string) (workloadinterface.IMetadata, error) {
+	if cloudDescribeDisabled() {
+		return nil, fmt.Errorf("%w: %s=true", ErrCloudDescribeUnavailable, KS_OFFLINE_ENV_VAR)
+	}
+
 	var clusterInfo *cloudsupportv1.CloudProviderDescribe
 
 	switch cloudProvider {
@@ -75,15 +94,15 @@ func GetDescriptiveInfoFromCloudProvider(cluster string, cloudProvider string) (
 		aksSupport := cloudsupportv1.NewAKSSupport()
 		subscriptionID, err := aksSupport.GetSubscriptionID()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 		resourceGroup, err := aksSupport.GetResourceGroup()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 		clusterInfo, err = cloudsupportv1.GetClusterDescribeAKS(aksSupport, cluster, subscriptionID, resourceGroup)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 	default:
 		return nil, fmt.Errorf(cloudsupportv1.NotSupportedMsg)
@@ -94,6 +113,10 @@ func GetDescriptiveInfoFromCloudProvider(cluster string, cloudProvider string) (
 
 // GetDescribeRepositoriesFromCloudProvider returns image repository descriptions from the cloud provider wrapped in IMetadata obj
 func GetDescribeRepositoriesFromCloudProvider(cluster string, cloudProvider string) (workloadinterface.IMetadata, error) {
+	if cloudDescribeDisabled() {
+		return nil, fmt.Errorf("%w: %s=true", ErrCloudDescribeUnavailable, KS_OFFLINE_ENV_VAR)
+	}
+
 	var clusterInfo *cloudsupportv1.CloudProviderDescribeRepositories
 
 	switch cloudProvider {
@@ -122,6 +145,10 @@ func GetDescribeRepositoriesFromCloudProvider(cluster string, cloudProvider stri
 
 // GetListEntitiesForPoliciesFromCloudProvider returns EntitiesForpolicies from the cloud provider wrapped in IMetadata obj
 func GetListEntitiesForPoliciesFromCloudProvider(cluster string, cloudProvider string) (workloadinterface.IMetadata, error) {
+	if cloudDescribeDisabled() {
+		return nil, fmt.Errorf("%w: %s=true", ErrCloudDescribeUnavailable, KS_OFFLINE_ENV_VAR)
+	}
+
 	var listEntitiesForPolicies *cloudsupportv1.CloudProviderListEntitiesForPolicies
 
 	switch cloudProvider {
@@ -142,15 +169,15 @@ func GetListEntitiesForPoliciesFromCloudProvider(cluster string, cloudProvider s
 		aksSupport := cloudsupportv1.NewAKSSupport()
 		subscriptionID, err := aksSupport.GetSubscriptionID()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 		resourceGroup, err := aksSupport.GetResourceGroup()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 		listEntitiesForPolicies, err = cloudsupportv1.GetListEntitiesForPoliciesAKS(aksSupport, cluster, subscriptionID, resourceGroup)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 	default:
 		return nil, fmt.Errorf(cloudsupportv1.NotSupportedMsg)
@@ -161,6 +188,10 @@ func GetListEntitiesForPoliciesFromCloudProvider(cluster string, cloudProvider s
 
 // GetPolicyVersionFromCloudProvider returns PolicyVersion from the cloud provider wrapped in IMetadata obj
 func GetPolicyVersionFromCloudProvider(cluster string, cloudProvider string) (workloadinterface.IMetadata, error) {
+	if cloudDescribeDisabled() {
+		return nil, fmt.Errorf("%w: %s=true", ErrCloudDescribeUnavailable, KS_OFFLINE_ENV_VAR)
+	}
+
 	var policyVersion *cloudsupportv1.CloudProviderPolicyVersion
 
 	switch cloudProvider {
@@ -181,15 +212,15 @@ func GetPolicyVersionFromCloudProvider(cluster string, cloudProvider string) (wo
 		aksSupport := cloudsupportv1.NewAKSSupport()
 		subscriptionID, err := aksSupport.GetSubscriptionID()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 		resourceGroup, err := aksSupport.GetResourceGroup()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 		policyVersion, err = cloudsupportv1.GetPolicyVersionAKS(aksSupport, cluster, subscriptionID, resourceGroup)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %v", ErrCloudDescribeUnavailable, err)
 		}
 	default:
 		return nil, fmt.Errorf(cloudsupportv1.NotSupportedMsg)

--- a/cloudsupport/cloudproviderconfiguration_test.go
+++ b/cloudsupport/cloudproviderconfiguration_test.go
@@ -1,0 +1,72 @@
+package cloudsupport
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	cloudsupportv1 "github.com/kubescape/k8s-interface/cloudsupport/v1"
+)
+
+func TestKSOfflineShortCircuitsCloudDescribe(t *testing.T) {
+	t.Setenv(KS_OFFLINE_ENV_VAR, "true")
+
+	entryPoints := map[string]func(string, string) (interface{}, error){
+		"GetDescriptiveInfoFromCloudProvider": func(c, p string) (interface{}, error) {
+			return GetDescriptiveInfoFromCloudProvider(c, p)
+		},
+		"GetDescribeRepositoriesFromCloudProvider": func(c, p string) (interface{}, error) {
+			return GetDescribeRepositoriesFromCloudProvider(c, p)
+		},
+		"GetListEntitiesForPoliciesFromCloudProvider": func(c, p string) (interface{}, error) {
+			return GetListEntitiesForPoliciesFromCloudProvider(c, p)
+		},
+		"GetPolicyVersionFromCloudProvider": func(c, p string) (interface{}, error) {
+			return GetPolicyVersionFromCloudProvider(c, p)
+		},
+	}
+
+	for name, fn := range entryPoints {
+		t.Run(name, func(t *testing.T) {
+			got, err := fn("any-cluster", cloudsupportv1.AKS)
+			if got != nil {
+				t.Fatalf("%s: expected nil result when offline, got %v", name, got)
+			}
+			if !errors.Is(err, ErrCloudDescribeUnavailable) {
+				t.Fatalf("%s: expected ErrCloudDescribeUnavailable, got %v", name, err)
+			}
+		})
+	}
+}
+
+// AKS path returns ErrCloudDescribeUnavailable (rather than a bare error) when
+// AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP are not set. This is the
+// failure mode real air-gapped users hit before any network call is attempted,
+// and it's what lets the kubescape scan loop classify the failure as
+// non-fatal.
+func TestAKSMissingCredsWrapsSentinel(t *testing.T) {
+	os.Unsetenv(KS_OFFLINE_ENV_VAR)
+	os.Unsetenv(cloudsupportv1.AZURE_SUBSCRIPTION_ID_ENV_VAR)
+	os.Unsetenv(cloudsupportv1.AZURE_RESOURCE_GROUP_ENV_VAR)
+
+	cases := map[string]func(string, string) (interface{}, error){
+		"GetDescriptiveInfoFromCloudProvider": func(c, p string) (interface{}, error) {
+			return GetDescriptiveInfoFromCloudProvider(c, p)
+		},
+		"GetListEntitiesForPoliciesFromCloudProvider": func(c, p string) (interface{}, error) {
+			return GetListEntitiesForPoliciesFromCloudProvider(c, p)
+		},
+		"GetPolicyVersionFromCloudProvider": func(c, p string) (interface{}, error) {
+			return GetPolicyVersionFromCloudProvider(c, p)
+		},
+	}
+
+	for name, fn := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := fn("any-cluster", cloudsupportv1.AKS)
+			if !errors.Is(err, ErrCloudDescribeUnavailable) {
+				t.Fatalf("%s: expected ErrCloudDescribeUnavailable, got %v", name, err)
+			}
+		})
+	}
+}

--- a/cloudsupport/cloudproviderconfiguration_test.go
+++ b/cloudsupport/cloudproviderconfiguration_test.go
@@ -39,15 +39,33 @@ func TestKSOfflineShortCircuitsCloudDescribe(t *testing.T) {
 	}
 }
 
+// unsetEnvWithCleanup unsets an env var for the duration of the test and
+// restores its original value (or absence) via t.Cleanup, so concurrent or
+// subsequent tests are not affected.
+func unsetEnvWithCleanup(t *testing.T, key string) {
+	t.Helper()
+	prev, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			os.Setenv(key, prev)
+		} else {
+			os.Unsetenv(key)
+		}
+	})
+}
+
 // AKS path returns ErrCloudDescribeUnavailable (rather than a bare error) when
 // AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP are not set. This is the
 // failure mode real air-gapped users hit before any network call is attempted,
 // and it's what lets the kubescape scan loop classify the failure as
 // non-fatal.
 func TestAKSMissingCredsWrapsSentinel(t *testing.T) {
-	os.Unsetenv(KS_OFFLINE_ENV_VAR)
-	os.Unsetenv(cloudsupportv1.AZURE_SUBSCRIPTION_ID_ENV_VAR)
-	os.Unsetenv(cloudsupportv1.AZURE_RESOURCE_GROUP_ENV_VAR)
+	unsetEnvWithCleanup(t, KS_OFFLINE_ENV_VAR)
+	unsetEnvWithCleanup(t, cloudsupportv1.AZURE_SUBSCRIPTION_ID_ENV_VAR)
+	unsetEnvWithCleanup(t, cloudsupportv1.AZURE_RESOURCE_GROUP_ENV_VAR)
 
 	cases := map[string]func(string, string) (interface{}, error){
 		"GetDescriptiveInfoFromCloudProvider": func(c, p string) (interface{}, error) {

--- a/cloudsupport/cloudproviderconfiguration_test.go
+++ b/cloudsupport/cloudproviderconfiguration_test.go
@@ -50,9 +50,13 @@ func unsetEnvWithCleanup(t *testing.T, key string) {
 	}
 	t.Cleanup(func() {
 		if had {
-			os.Setenv(key, prev)
+			if err := os.Setenv(key, prev); err != nil {
+				t.Errorf("restore %s: %v", key, err)
+			}
 		} else {
-			os.Unsetenv(key)
+			if err := os.Unsetenv(key); err != nil {
+				t.Errorf("unset %s: %v", key, err)
+			}
 		}
 	})
 }

--- a/cloudsupport/v1/akssupport.go
+++ b/cloudsupport/v1/akssupport.go
@@ -20,9 +20,15 @@ var (
 	AZURE_RESOURCE_GROUP_ENV_VAR  = "AZURE_RESOURCE_GROUP"
 )
 
-// Bounds every Azure credential and ARM call so an air-gapped or otherwise
-// unreachable Azure control plane cannot stall the scan loop.
-const aksCallTimeout = 5 * time.Second
+// Bounds Azure credential and ARM calls so an air-gapped or otherwise
+// unreachable Azure control plane cannot stall the scan loop. The single-call
+// budget is tight for cluster-describe; RBAC enumeration paginates and may
+// issue many GetByID calls on healthy subscriptions, so it gets a larger
+// budget to avoid downgrading legitimate latency to ErrCloudDescribeUnavailable.
+const (
+	aksCallTimeout            = 5 * time.Second
+	aksRBACEnumerationTimeout = 30 * time.Second
+)
 
 type IAKSSupport interface {
 	GetClusterDescribe(subscriptionId string, clusterName string, resourceGroup string) (*armcontainerservice.ManagedCluster, error)
@@ -99,7 +105,7 @@ func (AKSSupport *AKSSupport) GetResourceGroup() (string, error) {
 // resource group ID (format:'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or
 // resource ID (format:'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'
 func (AKSSupport *AKSSupport) ListAllRolesForScope(subscriptionId string, scope string) (*ListRoleAssignment, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), aksCallTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), aksRBACEnumerationTimeout)
 	defer cancel()
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -134,7 +140,7 @@ func (AKSSupport *AKSSupport) ListAllRolesForScope(subscriptionId string, scope 
 
 // ListAllRoleDefinitions - List all role definitions that are assigned in this scope
 func (AKSSupport *AKSSupport) ListAllRoleDefinitions(subscriptionId string, scope string) (*ListRoleDefinition, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), aksCallTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), aksRBACEnumerationTimeout)
 	defer cancel()
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/cloudsupport/v1/akssupport.go
+++ b/cloudsupport/v1/akssupport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	// "github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-04-30/containerservice"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -18,6 +19,10 @@ var (
 	AZURE_SUBSCRIPTION_ID_ENV_VAR = "AZURE_SUBSCRIPTION_ID"
 	AZURE_RESOURCE_GROUP_ENV_VAR  = "AZURE_RESOURCE_GROUP"
 )
+
+// Bounds every Azure credential and ARM call so an air-gapped or otherwise
+// unreachable Azure control plane cannot stall the scan loop.
+const aksCallTimeout = 5 * time.Second
 
 type IAKSSupport interface {
 	GetClusterDescribe(subscriptionId string, clusterName string, resourceGroup string) (*armcontainerservice.ManagedCluster, error)
@@ -45,6 +50,8 @@ func NewAKSSupport() *AKSSupport {
 
 // Get descriptive info about cluster running in AKS.
 func (AKSSupport *AKSSupport) GetClusterDescribe(subscriptionId string, clusterName string, resourceGroup string) (*armcontainerservice.ManagedCluster, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), aksCallTimeout)
+	defer cancel()
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
@@ -54,8 +61,6 @@ func (AKSSupport *AKSSupport) GetClusterDescribe(subscriptionId string, clusterN
 	if err != nil {
 		return nil, err
 	}
-
-	ctx := context.Background()
 
 	resp, err := aksclient.Get(ctx, resourceGroup, clusterName, nil)
 	if err != nil {
@@ -94,12 +99,13 @@ func (AKSSupport *AKSSupport) GetResourceGroup() (string, error) {
 // resource group ID (format:'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}', or
 // resource ID (format:'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/[{parentResourcePath}/]{resourceType}/{resourceName}'
 func (AKSSupport *AKSSupport) ListAllRolesForScope(subscriptionId string, scope string) (*ListRoleAssignment, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), aksCallTimeout)
+	defer cancel()
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, err
 	}
-	ctx := context.Background()
 
 	client, err := armauthorizationv2.NewRoleAssignmentsClient(subscriptionId, cred, nil)
 	if err != nil {
@@ -128,11 +134,13 @@ func (AKSSupport *AKSSupport) ListAllRolesForScope(subscriptionId string, scope 
 
 // ListAllRoleDefinitions - List all role definitions that are assigned in this scope
 func (AKSSupport *AKSSupport) ListAllRoleDefinitions(subscriptionId string, scope string) (*ListRoleDefinition, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), aksCallTimeout)
+	defer cancel()
+
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain a credential: %v", err)
 	}
-	ctx := context.Background()
 	listRoleAssignment, err := AKSSupport.ListAllRolesForScope(subscriptionId, scope)
 	var roleDefinitionList []*armauthorization.RoleDefinition
 	if err != nil {


### PR DESCRIPTION
 ## Summary                                                                                                                                                                     
                                                                                                                                                                                 
  Fixes the AKS air-gap path where `cloudsupport.GetDescriptiveInfoFromCloudProvider`                                                                                            
  hangs indefinitely on `azidentity.NewDefaultAzureCredential` and unbounded ARM                                                                                                 
  calls, starving the kubescape scan loop. Resolves the root cause behind                                                                                                        
  [kubescape/helm-charts#637](https://github.com/kubescape/helm-charts/issues/637).                                                                                              
                                                                                                                                                                                 
  The cloud-describe step is now **best-effort**:                                                                                                                                
                                                                                                                                                                                 
  - All Azure credential and ARM calls are bounded by a 5-second context timeout.                                                                                                
  - A new sentinel `ErrCloudDescribeUnavailable` is returned when describe fails                                                                                               
    for non-fatal reasons (offline mode, missing creds, network unreachable).                                                                                                    
  - A `KS_OFFLINE=true` short-circuit skips cloud-describe entirely. This env var                                                                                                
    is already set by the Helm chart when `capabilities.kubescapeOffline=enable`.                                                                                                
                                                                                                                                                                                 
  Callers in `kubescape` recognize the sentinel via `errors.Is` and continue the                                                                                                 
  scan instead of aborting, so host-scanner / node-agent data still gets                                                                                                         
  collected and persisted.                                                                                                                                                       
                                                                                                                                                                               
  ## Why this matters                                                                                                                                                            
                                                            
  In an AKS air-gapped cluster:                                                                                                                                                  
  1. `cloudsupport.GetCloudProvider` detects AKS via the node's `azure://` providerID.
  2. The describe path calls `azidentity.NewDefaultAzureCredential(nil)` which                                                                                                   
     probes IMDS at `169.254.169.254` and the AAD token endpoint.                                                                                                                
  3. With egress to those endpoints blocked, every credential source in the                                                                                                      
     chain hits its own connect timeout sequentially, then the ARM `Get` call                                                                                                    
     hangs against a non-routable ARM endpoint.                                                                                                                                  
  4. The total stall is on the order of minutes per scan iteration, which                                                                                                        
     prevents the host-scanner reporting pipeline from completing in time,                                                                                                 
     the symptom users see is missing `cniinfo-*`, `kubeletinfo-*`,                                                                                                              
     `kubeproxyinfo-*`, and `controlplaneinfo-*` workloadconfigurationscan CRDs.                                                                                                 
                                                                                                                                                                                 
  ## Changes                                                                                                                                                                     
                                                                                                                                                                                 
  ### `cloudsupport/v1/akssupport.go`                                                                                                                                            
  - New `aksCallTimeout = 5 * time.Second` constant.
  - `GetClusterDescribe`, `ListAllRolesForScope`, `ListAllRoleDefinitions` now                                                                                                   
    derive a deadline-bound `ctx` via `context.WithTimeout` and pass it into                                                                                                     
    the Azure SDK call. Failures are bounded; no behavioural change when the                                                                                                     
    control plane is reachable.                                                                                                                                                  
                                                                                                                                                                                 
  ### `cloudsupport/cloudproviderconfiguration.go`                                                                                                                               
  - New `ErrCloudDescribeUnavailable` sentinel error.       
  - New `KS_OFFLINE_ENV_VAR` constant + `cloudDescribeDisabled()` helper.                                                                                                        
  - All four entry points (`GetDescriptiveInfoFromCloudProvider`,                                                                                                                
    `GetDescribeRepositoriesFromCloudProvider`,                                                                                                                                  
    `GetListEntitiesForPoliciesFromCloudProvider`,                                                                                                                               
    `GetPolicyVersionFromCloudProvider`) short-circuit at the top with the                                                                                                       
    sentinel when `KS_OFFLINE=true`.                                                                                                                                             
  - AKS-branch errors (subscription/resource-group missing, ARM call failed)                                                                                                     
    are wrapped with the sentinel so callers can `errors.Is` and treat them                                                                                                      
    as non-fatal.                                                                                                                                                                
                                                                                                                                                                                 
  ### `cloudsupport/cloudproviderconfiguration_test.go` (new)                                                                                                                    
  - `TestKSOfflineShortCircuitsCloudDescribe` — asserts every entry point honors
    `KS_OFFLINE=true` and returns `ErrCloudDescribeUnavailable`.                                                                                                                 
  - `TestAKSMissingCredsWrapsSentinel` — asserts the AKS error path returns                                                                                                      
    the sentinel even without `KS_OFFLINE`, which is the realistic state for                                                                                                     
    air-gapped users with no Azure creds configured.                                                                                                                             
                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                   
                                                            
  ### Unit                                                                                                                                                                       
  - [x] `go test ./cloudsupport/...` — all green, incl. existing AKS describe tests.
  - [x] `go vet ./cloudsupport/...` — clean.                                                                                                                                     
                                                            
  ### End-to-end (kind, simulated AKS air-gap)                                                                                                                                   
  - [x] 3-node kind cluster with `azure://...` providerID baked into kubelet
        config per node, so `cloudsupport.GetCloudProvider` returns AKS.                                                                                                         
  - [x] iptables `OUTPUT -d 169.254.169.254 -j DROP` on every node to simulate                                                                                                   
        IMDS unreachability the AKS-style way (drop, not reject).                                                                                                                
  - [x] kubescape installed via Helm with `capabilities.kubescapeOffline=enable`,                                                                                                
        using a custom image built from this PR + a corresponding kubescape                                                                                                      
        consumer-side patch.                                                                                                                                                     
  - [x] Triggered scan completed in 49s (vs. minutes-long stall on stock build).                                                                                                 
  - [x] `Downloading cloud resources...` → `Downloaded cloud resources` finished                                                                                                 
        within the same second; no `DefaultAzureCredential` traces in the log.                                                                                                   
  - [x] Scan report carries `cloud-describe-unavailable` next to AKS-specific                                                                                                    
        controls (CIS-AKS, "Manage Kubernetes RBAC users with Azure AD", etc.) —                                                                                                 
        the sentinel propagates into user-facing output.                                                                                                                         
  - [x] All 11 frameworks scored normally (security, AllControls, ArmoBest,                                                                                                      
        cis-aks-t1.2.0, cis-aks-t1.8.0, cis-v1.10.0, cis-v1.12.0, DevOpsBest,                                                                                                    
        MITRE, NSA, SOC2) — proves AKS detection still happens and the rest of                                                                                                   
        the scan pipeline is unaffected.                                                                                                                                         
                                                                                                                                                                                 
  ## Risk / compatibility                                                                                                                                                        
                                                                                                                                                                                 
  - Public API surface unchanged. `IAKSSupport` interface signatures preserved,                                                                                                  
    so existing mocks (`AKSSupportMock`) and consumers compile without changes.                                                                                                  
  - New exported symbols: `ErrCloudDescribeUnavailable`, `KS_OFFLINE_ENV_VAR`.                                                                                                   
    Both additive.                                                                                                                                                               
  - Older consumers that don't recognize `ErrCloudDescribeUnavailable` see a                                                                                                     
    wrapped error and fall through to whatever their existing fallback path is —                                                                                                 
    no regression vs. today.                                                                                                                                                     
  - The 5s timeout is a hard bound on the happy path. Real-AKS users with a                                                                                                      
    reachable control plane should see no behavioural change; if anyone                                                                                                          
    regularly relies on cloud-describe taking >5s, they'd notice — but that                                                                                                      
    would already be a symptom of an unhealthy AKS connection.                                                                                                                   
                                                                                                                                                                                 
  ## Follow-ups (separate PRs)                                                                                                                                                   
                                                                                                                                                                                 
  - `kubescape`: bump `k8s-interface`, update                                                                                                                                    
    `core/pkg/resourcehandler/k8sresources.go` to recognize the sentinel and
    log + continue. (Branch ready.)    PR For that - https://github.com/kubescape/kubescape/pull/2003                                                                                                                                    
  - `kubescape/operator`: bump `k8s-interface` go.mod (no code change needed).                                                                                                   
  - Optional: apply the same `context.WithTimeout` pattern to                                                                                                                    
    `cloudsupport/v1/ekssupport.go` and `gkesupport.go` for symmetry. AWS/GCP                                                                                                    
    SDKs fail faster in practice, so this is a robustness nice-to-have rather                                                                                                    
    than a fix for a reported bug.                          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline mode lets cloud provider describe operations be fully skipped to avoid unnecessary calls.
  * Added timeouts for Azure interactions to prevent hanging requests.

* **Bug Fixes**
  * Improved error signaling so callers can reliably detect when cloud-describe operations are unavailable or fail due to air-gapped/missing-credentials scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->