### PR TITLE
fix(discovery): preserve all groups serving the same resource name

### DIFF
--- a/k8sinterface/k8sdiscovery.go
+++ b/k8sinterface/k8sdiscovery.go
@@ -323,10 +323,15 @@ func getResourceTriplets(group, version, resource string) []string {
 			}
 		}
 	} else if group == "" {
-		// load by resource and version - emit one triplet per known group serving the resource.
+		// load by resource and version - emit one triplet per known group serving the
+		// resource, but only for entries whose discovered version actually matches
+		// the requested version. Otherwise we'd synthesize group/version pairs the
+		// cluster never advertised (e.g. extensions/v1/ingresses when discovery
+		// only recorded extensions/v1beta1).
 		if vs, ok := GetResourceFromGroupMapping(resource); ok {
 			for _, v := range vs {
-				if g := strings.Split(v, "/"); len(g) >= 1 {
+				g := strings.Split(v, "/")
+				if len(g) >= 2 && g[1] == version {
 					resourceTriplets = append(resourceTriplets, JoinResourceTriplets(g[0], version, resource))
 				}
 			}

--- a/k8sinterface/k8sdiscovery.go
+++ b/k8sinterface/k8sdiscovery.go
@@ -17,8 +17,10 @@ const (
 	ResourceForbiddenErr = "is forbidden"
 )
 
-// ResourceGroupMapping mapping of all supported Kubernetes cluster resources to apiVersion
-var resourceGroupMapping = map[string]string{}
+// ResourceGroupMapping mapping of all supported Kubernetes cluster resources to a list of apiVersions.
+// A single resource name (e.g. "ingresses") may be served by more than one API group
+// (e.g. "networking.k8s.io/v1" and "extensions/v1beta1"), so the value is a slice.
+var resourceGroupMapping = map[string][]string{}
 var resourceNamesapcedScope = []string{} // use this to determan if the resource is namespaced
 
 // RW locker to ensure we won't read/write concurrently the map/slice of resources
@@ -27,22 +29,20 @@ var resourcesInfoLock = sync.RWMutex{}
 // DEPRECATED - use the 'ResourceNamesapcedScope' instead
 var ResourceClusterScope = []string{}
 
+// GetSingleResourceFromGroupMapping returns the first known group/version for the resource.
+// Kept for backward compatibility. Callers that need every group serving a resource should
+// use GetResourceFromGroupMapping.
 func GetSingleResourceFromGroupMapping(resource string) (string, bool) {
-	resourcesInfoLock.RLock()
-	rsrcGroupMappingLength := len(resourceGroupMapping)
-	resourcesInfoLock.RUnlock()
-
-	if rsrcGroupMappingLength == 0 {
-		InitializeMapResources(nil)
+	gvs, ok := GetResourceFromGroupMapping(resource)
+	if !ok || len(gvs) == 0 {
+		return "", false
 	}
-	resourcesInfoLock.RLock()
-	defer resourcesInfoLock.RUnlock()
-	r, k := resourceGroupMapping[updateResourceKind(resource)]
-	return r, k
+	return gvs[0], true
 }
 
-// GetResourceGroupMapping returns copy of ResourceGroupMapping map object
-func GetResourceGroupMapping() map[string]string {
+// GetResourceFromGroupMapping returns every known group/version for the given resource name.
+// Returns (nil, false) when the resource is unknown.
+func GetResourceFromGroupMapping(resource string) ([]string, bool) {
 	resourcesInfoLock.RLock()
 	rsrcGroupMappingLength := len(resourceGroupMapping)
 	resourcesInfoLock.RUnlock()
@@ -52,11 +52,47 @@ func GetResourceGroupMapping() map[string]string {
 	}
 	resourcesInfoLock.RLock()
 	defer resourcesInfoLock.RUnlock()
-	copyOfresourceMapping := make(map[string]string, len(resourceGroupMapping))
-	for k := range resourceGroupMapping {
-		copyOfresourceMapping[k] = resourceGroupMapping[k]
+	gvs, ok := resourceGroupMapping[updateResourceKind(resource)]
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, len(gvs))
+	copy(out, gvs)
+	return out, true
+}
+
+// GetResourceGroupMapping returns a copy of the resource→group/version map, with one
+// group per resource (the first one discovered). Kept for backward compatibility. Use
+// GetAllResourceGroupMappings if you need every group serving each resource.
+func GetResourceGroupMapping() map[string]string {
+	all := GetAllResourceGroupMappings()
+	copyOfresourceMapping := make(map[string]string, len(all))
+	for k, v := range all {
+		if len(v) > 0 {
+			copyOfresourceMapping[k] = v[0]
+		}
 	}
 	return copyOfresourceMapping
+}
+
+// GetAllResourceGroupMappings returns a copy of the full resource→[]group/version map.
+func GetAllResourceGroupMappings() map[string][]string {
+	resourcesInfoLock.RLock()
+	rsrcGroupMappingLength := len(resourceGroupMapping)
+	resourcesInfoLock.RUnlock()
+
+	if rsrcGroupMappingLength == 0 {
+		InitializeMapResources(nil)
+	}
+	resourcesInfoLock.RLock()
+	defer resourcesInfoLock.RUnlock()
+	out := make(map[string][]string, len(resourceGroupMapping))
+	for k, v := range resourceGroupMapping {
+		cp := make([]string, len(v))
+		copy(cp, v)
+		out[k] = cp
+	}
+	return out
 }
 
 func GetResourceNamesapcedScope() []string {
@@ -125,15 +161,24 @@ func setMapResources(resourceList []*metav1.APIResourceList) {
 				continue
 			}
 
-			resourcesInfoLock.RLock()
-			_, ok := resourceGroupMapping[apiResource.Name]
-			resourcesInfoLock.RUnlock()
-			if ok { // do not override resources in map
-				continue
-			}
+			gvStr := JoinGroupVersion(gv.Group, gv.Version)
 
 			resourcesInfoLock.Lock()
-			resourceGroupMapping[apiResource.Name] = JoinGroupVersion(gv.Group, gv.Version)
+			// Append the group/version, deduping in case discovery returns the same
+			// (resource, group, version) tuple twice. Multiple groups serving the same
+			// resource name (e.g. "ingresses" in networking.k8s.io and extensions) are
+			// all preserved in insertion order.
+			existing := resourceGroupMapping[apiResource.Name]
+			alreadyPresent := false
+			for _, e := range existing {
+				if e == gvStr {
+					alreadyPresent = true
+					break
+				}
+			}
+			if !alreadyPresent {
+				resourceGroupMapping[apiResource.Name] = append(existing, gvStr)
+			}
 			if apiResource.Namespaced {
 				resourceNamesapcedScope = append(resourceNamesapcedScope, JoinResourceTriplets(gv.Group, gv.Version, apiResource.Name))
 			} else { // DEPRECATED
@@ -251,35 +296,40 @@ func getResourceTriplets(group, version, resource string) []string {
 
 	resourceTriplets := []string{}
 	if resource == "" {
-		// load full map
-		for k, v := range GetResourceGroupMapping() {
-			if g := strings.Split(v, "/"); len(g) >= 2 {
-				resourceTriplets = append(resourceTriplets, JoinResourceTriplets(g[0], g[1], k))
+		// load full map - one triplet per (resource, group/version) pair so that
+		// resources served by multiple groups are not collapsed.
+		for k, vs := range GetAllResourceGroupMappings() {
+			for _, v := range vs {
+				if g := strings.Split(v, "/"); len(g) >= 2 {
+					resourceTriplets = append(resourceTriplets, JoinResourceTriplets(g[0], g[1], k))
+				}
 			}
 		}
 	} else if version == "" {
-		// load by resource
-		if v, ok := GetSingleResourceFromGroupMapping(resource); ok {
-			g := strings.Split(v, "/")
-			if len(g) >= 2 {
-				if group == "" {
-					group = g[0]
+		// load by resource - emit one triplet per known group/version for the resource.
+		if vs, ok := GetResourceFromGroupMapping(resource); ok {
+			for _, v := range vs {
+				g := strings.Split(v, "/")
+				if len(g) >= 2 {
+					triplGroup := group
+					if triplGroup == "" {
+						triplGroup = g[0]
+					} else if triplGroup != g[0] {
+						// caller pinned a specific group, skip groups that don't match
+						continue
+					}
+					resourceTriplets = append(resourceTriplets, JoinResourceTriplets(triplGroup, g[1], resource))
 				}
-				resourceTriplets = append(resourceTriplets, JoinResourceTriplets(group, g[1], resource))
 			}
-		} else {
-			// DO NOT USE GLOG
-			// glog.Errorf("Resource '%s' unknown", resource)
 		}
 	} else if group == "" {
-		// load by resource and version
-		if v, ok := GetSingleResourceFromGroupMapping(resource); ok {
-			if g := strings.Split(v, "/"); len(g) >= 1 {
-				resourceTriplets = append(resourceTriplets, JoinResourceTriplets(g[0], version, resource))
+		// load by resource and version - emit one triplet per known group serving the resource.
+		if vs, ok := GetResourceFromGroupMapping(resource); ok {
+			for _, v := range vs {
+				if g := strings.Split(v, "/"); len(g) >= 1 {
+					resourceTriplets = append(resourceTriplets, JoinResourceTriplets(g[0], version, resource))
+				}
 			}
-		} else {
-			// DO NOT USE GLOG
-			// glog.Errorf("Resource '%s' unknown", resource)
 		}
 	} else {
 		resourceTriplets = append(resourceTriplets, JoinResourceTriplets(group, version, resource))

--- a/k8sinterface/k8sdiscovery_test.go
+++ b/k8sinterface/k8sdiscovery_test.go
@@ -135,6 +135,20 @@ func TestMultiGroupResource(t *testing.T) {
 	// pinning the group should narrow the result to that group only
 	pinned := ResourceGroupToString("extensions", "", "Ingress")
 	assert.Equal(t, []string{"extensions/v1beta1/ingresses"}, pinned)
+
+	// pinning the version with a wildcarded group must only emit groups whose
+	// discovered version matches. extensions only serves v1beta1 in the mock,
+	// so a v1 lookup must skip it and only return networking.k8s.io/v1.
+	versionPinned := ResourceGroupToString("*", "v1", "Ingress")
+	assert.Equal(t, []string{"networking.k8s.io/v1/ingresses"}, versionPinned)
+
+	// asking for a version no group serves should return nothing.
+	missingVersion := ResourceGroupToString("*", "v2", "Ingress")
+	assert.Empty(t, missingVersion)
+
+	// the v1beta1 lookup must hit extensions and skip networking.k8s.io's v1 entry.
+	betaPinned := ResourceGroupToString("*", "v1beta1", "Ingress")
+	assert.Equal(t, []string{"extensions/v1beta1/ingresses"}, betaPinned)
 }
 
 func TestIsTypeWorkload(t *testing.T) {

--- a/k8sinterface/k8sdiscovery_test.go
+++ b/k8sinterface/k8sdiscovery_test.go
@@ -14,8 +14,12 @@ func TestResourceGroupToString(t *testing.T) {
 	InitializeMapResourcesMock()
 
 	allResources := ResourceGroupToString("*", "*", "*")
-	if len(allResources) != len(GetResourceGroupMapping()) {
-		t.Errorf("Expected len: %d, received: %d", len(GetResourceGroupMapping()), len(allResources))
+	expectedTotal := 0
+	for _, gvs := range GetAllResourceGroupMappings() {
+		expectedTotal += len(gvs)
+	}
+	if len(allResources) != expectedTotal {
+		t.Errorf("Expected len: %d, received: %d", expectedTotal, len(allResources))
 	}
 	pod := ResourceGroupToString("*", "*", "Pod")
 	if len(pod) == 0 || pod[0] != "/v1/pods" {
@@ -110,6 +114,27 @@ func TestInitializeMapResourcesMock(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, v, v2, fmt.Sprintf("resource: %s", k))
 	}
+}
+
+// TestMultiGroupResource covers resources that are served under more than one
+// API group. The mock data exposes "ingresses" under both networking.k8s.io/v1
+// and extensions/v1beta1; both must be discoverable.
+func TestMultiGroupResource(t *testing.T) {
+	InitializeMapResourcesMock()
+
+	gvs, ok := GetResourceFromGroupMapping("ingresses")
+	assert.True(t, ok)
+	assert.Contains(t, gvs, "networking.k8s.io/v1")
+	assert.Contains(t, gvs, "extensions/v1beta1")
+
+	// wildcarded group lookup should return one triplet per group serving the resource
+	triplets := ResourceGroupToString("*", "*", "Ingress")
+	assert.Contains(t, triplets, "networking.k8s.io/v1/ingresses")
+	assert.Contains(t, triplets, "extensions/v1beta1/ingresses")
+
+	// pinning the group should narrow the result to that group only
+	pinned := ResourceGroupToString("extensions", "", "Ingress")
+	assert.Equal(t, []string{"extensions/v1beta1/ingresses"}, pinned)
 }
 
 func TestIsTypeWorkload(t *testing.T) {


### PR DESCRIPTION
## Summary 
                                                                                                                                                                                         
  So `resourceGroupMapping` was a `map[string]string`, one group per resource name. The discovery code in `setMapResources` had a guard that explicitly skipped any group that came in after the first one for a given resource name. That meant if a resource was served under more than one API group (the classic case being `ingresses` in both `networking.k8s.io` and
  `extensions`), only one of them stuck and the other just disappeared. No log, no warning, nothing. I changed the map to `map[string][]string` so we keep every group that serves a  resource, dropped the skip-on-second-write guard in `setMapResources` and replaced it with append plus dedup, and updated `getResourceTriplets` so the wildcarded lookups
  (`version==""`, `group==""`, `resource==""`) actually return one triplet per group instead of just one total. Added `GetResourceFromGroupMapping` and `GetAllResourceGroupMappings` for callers that want the full multi-group view. The single-group helpers (`GetSingleResourceFromGroupMapping`, `GetResourceGroupMapping`) are still there and just return the first entry
   now, so callers in other repos like opa-utils, node-agent etc don't break and don't need a go.mod bump. Fixes #150.                                         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Kubernetes resource discovery to recognize and enumerate multiple API groups/versions per resource, producing broader and more accurate discovery results (e.g., Ingress across groups/versions).

* **Tests**
  * Added tests validating multi-group/multi-version discovery behavior and updated existing tests to count resources across all known group/version mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->