### PR TITLE
feat: add OtelSpanIDMetadataKey annotation key

### DIFF
--- a/instanceidhandler/v1/helpers/keys.go
+++ b/instanceidhandler/v1/helpers/keys.go
@@ -26,6 +26,7 @@ const (
 	InitContainerNameMetadataKey       = metadataPrefix + "/workload-init-container-name" // DEPRECATED - use ContainerNameMetadataKey and ContainerTypeMetadataKey
 	InstanceIDMetadataKey              = metadataPrefix + "/instance-id"
 	LearningPeriodMetadataKey          = metadataPrefix + "/learning-period"
+	OtelSpanIDMetadataKey              = metadataPrefix + "/otel-span-id"
 	ManagedByMetadataKey               = metadataPrefix + "/managed-by"
 	PreviousReportTimestampMetadataKey = metadataPrefix + "/previous-report-timestamp"
 	RbacResourceMetadataKey            = metadataPrefix + "/rbac-resource"


### PR DESCRIPTION
## Summary

- Adds `OtelSpanIDMetadataKey = "kubescape.io/otel-span-id"` to the metadata key constants in `instanceidhandler/v1/helpers/keys.go`
- node-agent stamps this annotation on `ContainerProfile` objects with the hex span ID of the active `container.profile.learning` trace span
- Offline processors reading CPs from storage can use this span ID to parent their own spans, linking time-series processing work back into the live trace

## Test plan

- [ ] Constant is alphabetically ordered alongside existing keys
- [ ] node-agent PR #818 consumes this key once this module is released and the dependency is bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OpenTelemetry span ID metadata tracking support, enabling enhanced observability and improved diagnostics across distributed systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubescape/k8s-interface/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->