### PR TITLE
feat: add OtelTraceparentMetadataKey annotation constant

### DIFF
--- a/instanceidhandler/v1/helpers/keys.go
+++ b/instanceidhandler/v1/helpers/keys.go
@@ -27,6 +27,7 @@ const (
 	InstanceIDMetadataKey              = metadataPrefix + "/instance-id"
 	LearningPeriodMetadataKey          = metadataPrefix + "/learning-period"
 	OtelSpanIDMetadataKey              = metadataPrefix + "/otel-span-id"
+	OtelTraceparentMetadataKey         = metadataPrefix + "/otel-traceparent"
 	ManagedByMetadataKey               = metadataPrefix + "/managed-by"
 	PreviousReportTimestampMetadataKey = metadataPrefix + "/previous-report-timestamp"
 	RbacResourceMetadataKey            = metadataPrefix + "/rbac-resource"


### PR DESCRIPTION
## Summary

- Adds `OtelTraceparentMetadataKey = "kubescape.io/otel-traceparent"` alongside the existing `OtelSpanIDMetadataKey`
- The full W3C traceparent (`{version}-{trace-id}-{span-id}-{flags}`) is required by `kubescape/storage` to create properly parented child spans during CP aggregation — the span ID alone is insufficient because the trace ID is needed to reconstruct the remote span context

## Context

Part of the OpenTelemetry Phase 1 instrumentation in `kubescape/node-agent`. Each `ContainerProfile` checkpoint will carry this annotation so the storage aggregation step can open a child span within the original learning trace without requiring a separate lookup.

## Test plan

- [x] `go build ./...` passes
- [ ] Used by `kubescape/node-agent` monitoring.go — swap inline string `"kubescape.io/otel-traceparent"` for `helpersv1.OtelTraceparentMetadataKey` once this releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)