### PR TITLE
feat(helpers): add UnsupportedSchema status value

### DIFF
--- a/instanceidhandler/v1/helpers/keys.go
+++ b/instanceidhandler/v1/helpers/keys.go
@@ -86,14 +86,15 @@ const (
 
 // Statuses
 const (
-	Initializing   = "initializing"
-	Learning       = "ready"
-	Completed      = "completed"
-	Incomplete     = "incomplete"
-	Unauthorize    = "unauthorize"
-	MissingRuntime = "missing-runtime"
-	TooLarge       = "too-large"
-	Failed         = "failed" // container exited with a non-zero code
+	Initializing      = "initializing"
+	Learning          = "ready"
+	Completed         = "completed"
+	Incomplete        = "incomplete"
+	Unauthorize       = "unauthorize"
+	MissingRuntime    = "missing-runtime"
+	TooLarge          = "too-large"
+	Failed            = "failed" // container exited with a non-zero code
+	UnsupportedSchema = "unsupported-schema"
 )
 
 // Completion


### PR DESCRIPTION
## Overview

Adds a new `kubescape.io/status` value, `unsupported-schema`, to the shared
status vocabulary in `instanceidhandler/v1/helpers`.

It signals that an image's registry served a manifest schema the scanner
cannot read, so no SBOM/vulnerability data could be produced for the workload.
This sits alongside the existing degraded statuses (`incomplete`, `too-large`)
and gives consumers a recognized value to surface instead of treating the
workload as silently unscanned.

## Changes

- `instanceidhandler/v1/helpers/keys.go`: add `UnsupportedSchema = "unsupported-schema"`
  to the Statuses const block.

## Related issues/PRs

This is the foundation of a three-repo change. Merge order:
1. this PR (merge + release)
2. kubescape/storage - adds the value to `ValidateStatusAnnotation`
3. kubescape/kubevuln - writes the status on schema-unsupported scans (kubescape/kubevuln#369)

## Checklist

- [x] Commits signed off (DCO)
- [x] Builds and tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to provide specific status feedback when encountering schema configurations that are not supported by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->