### PR TITLE
Use comma-ok when reading string fields off a manifest

### DIFF
--- a/workloadinterface/basicobjectmethods.go
+++ b/workloadinterface/basicobjectmethods.go
@@ -58,11 +58,8 @@ func (b *BaseObject) GetObject() map[string]interface{} {
 }
 func (b *BaseObject) GetNamespace() string {
 	if v, ok := InspectWorkload(b.base, "metadata", "namespace"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -75,11 +72,8 @@ func (b *BaseObject) GetID() string {
 }
 func (b *BaseObject) GetName() string {
 	if v, ok := InspectWorkload(b.base, "metadata", "name"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -87,11 +81,8 @@ func (b *BaseObject) GetName() string {
 
 func (b *BaseObject) GetApiVersion() string {
 	if v, ok := InspectWorkload(b.base, "apiVersion"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -119,11 +110,8 @@ func (b *BaseObject) GetGroup() string {
 
 func (b *BaseObject) GetKind() string {
 	if v, ok := InspectWorkload(b.base, "kind"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""

--- a/workloadinterface/basicobjectmethods.go
+++ b/workloadinterface/basicobjectmethods.go
@@ -58,7 +58,12 @@ func (b *BaseObject) GetObject() map[string]interface{} {
 }
 func (b *BaseObject) GetNamespace() string {
 	if v, ok := InspectWorkload(b.base, "metadata", "namespace"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -70,14 +75,24 @@ func (b *BaseObject) GetID() string {
 }
 func (b *BaseObject) GetName() string {
 	if v, ok := InspectWorkload(b.base, "metadata", "name"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
 
 func (b *BaseObject) GetApiVersion() string {
 	if v, ok := InspectWorkload(b.base, "apiVersion"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -104,7 +119,12 @@ func (b *BaseObject) GetGroup() string {
 
 func (b *BaseObject) GetKind() string {
 	if v, ok := InspectWorkload(b.base, "kind"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }

--- a/workloadinterface/basicobjectmethods_test.go
+++ b/workloadinterface/basicobjectmethods_test.go
@@ -1,0 +1,46 @@
+package workloadinterface
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// IsBaseObject only checks that kind, apiVersion and metadata.name are
+// non-empty, never that they are strings, so a base object carrying non-string
+// values is accepted the same way a workload is.
+func TestBaseObjectAccessorsWithNonStringFields(t *testing.T) {
+	b, err := NewBaseObjBytes([]byte(`{
+		"apiVersion": ["oops"],
+		"kind": 1,
+		"metadata": {"name": 42, "namespace": ["oops"]}
+	}`))
+	assert.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		got  func(*BaseObject) string
+	}{
+		{"GetNamespace", (*BaseObject).GetNamespace},
+		{"GetName", (*BaseObject).GetName},
+		{"GetApiVersion", (*BaseObject).GetApiVersion},
+		{"GetKind", (*BaseObject).GetKind},
+		{"GetGroup", (*BaseObject).GetGroup},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, "", tc.got(b))
+		})
+	}
+
+	assert.NotPanics(t, func() { _ = b.GetID() })
+}
+
+func TestListWorkloadsAccessorsWithNonStringFields(t *testing.T) {
+	lw, err := NewListWorkloads([]byte(`{"apiVersion": ["oops"], "kind": 1, "metadata": {"name": 42}}`))
+	assert.NoError(t, err)
+
+	assert.Equal(t, "", lw.GetName())
+	assert.Equal(t, "", lw.GetApiVersion())
+	assert.Equal(t, "", lw.GetKind())
+	assert.NotPanics(t, func() { _ = lw.GetID() })
+}

--- a/workloadinterface/interfaceutils.go
+++ b/workloadinterface/interfaceutils.go
@@ -23,15 +23,24 @@ func InspectMap(mapobject interface{}, scopes ...string) (val interface{}, k boo
 
 func SetInMap(workload map[string]interface{}, scope []string, key string, val interface{}) {
 	for i := range scope {
-		if _, ok := workload[scope[i]]; !ok {
-			workload[scope[i]] = make(map[string]interface{})
+		// look the node up and assert in one step: testing only for presence
+		// leaves workload nil when the node exists but is not a map, and the
+		// assignment below then panics.
+		if m, ok := workload[scope[i]].(map[string]interface{}); ok {
+			workload = m
+			continue
 		}
-		workload, _ = workload[scope[i]].(map[string]interface{})
+		next := make(map[string]interface{})
+		workload[scope[i]] = next
+		workload = next
 	}
 
 	workload[key] = val
 }
 
+// RemoveFromMap walks the same way SetInMap does, so a node that is present
+// but not a map leaves workload nil here too. That is harmless because delete
+// on a nil map is a no-op, but do not turn the delete into an assignment.
 func RemoveFromMap(workload map[string]interface{}, scope ...string) {
 	for i := 0; i < len(scope)-1; i++ {
 		if _, ok := workload[scope[i]]; ok {

--- a/workloadinterface/listworkloadsmethods.go
+++ b/workloadinterface/listworkloadsmethods.go
@@ -40,14 +40,24 @@ func (lw *ListWorkloads) GetName() string {
 
 func (lw *ListWorkloads) GetKind() string {
 	if v, ok := InspectMap(lw.listWorkloads, "kind"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
 
 func (lw *ListWorkloads) GetApiVersion() string {
 	if v, ok := InspectMap(lw.listWorkloads, "apiVersion"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -116,7 +126,8 @@ func IsTypeListWorkloads(object map[string]interface{}) bool {
 	}
 
 	if v, ok := InspectMap(object, "kind"); ok {
-		return v.(string) == string(TypeListWorkloads)
+		s, ok := v.(string)
+		return ok && s == string(TypeListWorkloads)
 	}
 	return false
 }

--- a/workloadinterface/listworkloadsmethods.go
+++ b/workloadinterface/listworkloadsmethods.go
@@ -40,11 +40,8 @@ func (lw *ListWorkloads) GetName() string {
 
 func (lw *ListWorkloads) GetKind() string {
 	if v, ok := InspectMap(lw.listWorkloads, "kind"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -52,11 +49,8 @@ func (lw *ListWorkloads) GetKind() string {
 
 func (lw *ListWorkloads) GetApiVersion() string {
 	if v, ok := InspectMap(lw.listWorkloads, "apiVersion"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""

--- a/workloadinterface/workloadmethods.go
+++ b/workloadinterface/workloadmethods.go
@@ -79,7 +79,6 @@ func (w *Workload) ToUnstructured() (*unstructured.Unstructured, error) {
 	}
 	if err := json.Unmarshal(bWorkload, obj); err != nil {
 		return obj, err
-
 	}
 
 	return obj, nil
@@ -130,8 +129,10 @@ func (w *Workload) RemovePodLabel(key string) {
 	w.RemoveMetadata(PodMetadata(w.GetKind()), "labels", key)
 }
 
+// RemoveMetadata walks the same way SetInMap does, so a node that is present
+// but not a map leaves workload nil. Reading from and deleting on a nil map are
+// both no-ops, so this stays safe as long as nothing here assigns into workload.
 func (w *Workload) RemoveMetadata(scope []string, metadata, key string) {
-
 	workload := w.workload
 	for i := range scope {
 		if _, ok := workload[scope[i]]; !ok {
@@ -146,7 +147,6 @@ func (w *Workload) RemoveMetadata(scope []string, metadata, key string) {
 
 	labels, _ := workload[metadata].(map[string]interface{})
 	delete(labels, key)
-
 }
 
 // ========================================= SET =========================================
@@ -204,11 +204,8 @@ func (w *Workload) GetObject() map[string]interface{} {
 }
 func (w *Workload) GetNamespace() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "namespace"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -221,11 +218,8 @@ func (w *Workload) GetID() string {
 }
 func (w *Workload) GetName() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "name"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -233,18 +227,17 @@ func (w *Workload) GetName() string {
 
 func (w *Workload) GetData() map[string]interface{} {
 	if v, ok := InspectWorkload(w.workload, "data"); ok {
-		return v.(map[string]interface{})
+		if m, ok := v.(map[string]interface{}); ok {
+			return m
+		}
 	}
 	return nil
 }
 
 func (w *Workload) GetApiVersion() string {
 	if v, ok := InspectWorkload(w.workload, "apiVersion"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -272,11 +265,8 @@ func (w *Workload) GetGroup() string {
 
 func (w *Workload) GetGenerateName() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "generateName"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -304,11 +294,8 @@ func (w *Workload) GetReplicas() int {
 
 func (w *Workload) GetKind() string {
 	if v, ok := InspectWorkload(w.workload, "kind"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -316,8 +303,12 @@ func (w *Workload) GetKind() string {
 
 func (w *Workload) GetServiceSelector() map[string]string {
 	if v, ok := InspectWorkload(w.workload, "spec", "selector"); ok && v != nil {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
 		selector := make(map[string]string)
-		for k, i := range v.(map[string]interface{}) {
+		for k, i := range m {
 			selector[k] = fmt.Sprintf("%v", i)
 		}
 		return selector
@@ -377,14 +368,16 @@ func (w *Workload) GetPodLabel(label string) (string, bool) {
 
 func (w *Workload) GetLabels() map[string]string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "labels"); ok && v != nil {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
 		labels := make(map[string]string)
-		for k, i := range v.(map[string]interface{}) {
-			// null labels will be ignored
-			if i == nil {
-				continue
+		for k, i := range m {
+			// null and non-string labels are ignored
+			if s, ok := i.(string); ok {
+				labels[k] = s
 			}
-
-			labels[k] = i.(string)
 		}
 		return labels
 	}
@@ -398,9 +391,16 @@ func (w *Workload) GetInnerLabels() map[string]string {
 
 func (w *Workload) GetPodLabels() map[string]string {
 	if v, ok := InspectWorkload(w.workload, append(PodMetadata(w.GetKind()), "labels")...); ok && v != nil {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
 		labels := make(map[string]string)
-		for k, i := range v.(map[string]interface{}) {
-			labels[k] = i.(string)
+		for k, i := range m {
+			// null and non-string labels are ignored
+			if s, ok := i.(string); ok {
+				labels[k] = s
+			}
 		}
 		return labels
 	}
@@ -415,8 +415,12 @@ func (w *Workload) GetInnerAnnotations() map[string]string {
 // GetPodAnnotations
 func (w *Workload) GetPodAnnotations() map[string]string {
 	if v, ok := InspectWorkload(w.workload, append(PodMetadata(w.GetKind()), "annotations")...); ok && v != nil {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
 		annotations := make(map[string]string)
-		for k, i := range v.(map[string]interface{}) {
+		for k, i := range m {
 			annotations[k] = fmt.Sprintf("%v", i)
 		}
 		return annotations
@@ -440,8 +444,12 @@ func (w *Workload) GetPodAnnotation(annotation string) (string, bool) {
 
 func (w *Workload) GetAnnotations() map[string]string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "annotations"); ok && v != nil {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil
+		}
 		annotations := make(map[string]string)
-		for k, i := range v.(map[string]interface{}) {
+		for k, i := range m {
 			annotations[k] = fmt.Sprintf("%v", i)
 		}
 		return annotations
@@ -450,7 +458,6 @@ func (w *Workload) GetAnnotations() map[string]string {
 }
 
 func (w *Workload) GetServiceAccountName() string {
-
 	if v, ok := InspectWorkload(w.workload, append(PodSpec(w.GetKind()), "serviceAccountName")...); ok && v != nil {
 		if s, ok := v.(string); ok {
 			return s
@@ -565,28 +572,21 @@ func (w *Workload) GetOwnerReferences() ([]metav1.OwnerReference, error) {
 	err = json.Unmarshal(ownerReferencesBytes, &ownerReferences)
 	if err != nil {
 		return ownerReferences, err
-
 	}
 	return ownerReferences, nil
 }
 func (w *Workload) GetResourceVersion() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "resourceVersion"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
 }
 func (w *Workload) GetUID() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "uid"); ok {
-
 		if s, ok := v.(string); ok {
-
 			return s
-
 		}
 	}
 	return ""
@@ -665,7 +665,6 @@ func (w *Workload) GetSecretsOfContainer() (map[string][]string, error) {
 				}
 			}
 		}
-
 	}
 	return secretsOfContainer, nil
 }
@@ -713,7 +712,6 @@ func (w *Workload) GetConfigMapsOfContainer() (map[string][]string, error) {
 				}
 			}
 		}
-
 	}
 	return configMapsOfContainer, nil
 }

--- a/workloadinterface/workloadmethods.go
+++ b/workloadinterface/workloadmethods.go
@@ -204,7 +204,12 @@ func (w *Workload) GetObject() map[string]interface{} {
 }
 func (w *Workload) GetNamespace() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "namespace"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -216,7 +221,12 @@ func (w *Workload) GetID() string {
 }
 func (w *Workload) GetName() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "name"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -230,7 +240,12 @@ func (w *Workload) GetData() map[string]interface{} {
 
 func (w *Workload) GetApiVersion() string {
 	if v, ok := InspectWorkload(w.workload, "apiVersion"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -257,7 +272,12 @@ func (w *Workload) GetGroup() string {
 
 func (w *Workload) GetGenerateName() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "generateName"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -284,7 +304,12 @@ func (w *Workload) GetReplicas() int {
 
 func (w *Workload) GetKind() string {
 	if v, ok := InspectWorkload(w.workload, "kind"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
@@ -306,7 +331,9 @@ func (w *Workload) GetSelector() (*metav1.LabelSelector, error) {
 		if m, ok := matchLabels.(map[string]interface{}); ok {
 			selector.MatchLabels = make(map[string]string, len(m))
 			for k, v := range m {
-				selector.MatchLabels[k] = v.(string)
+				if s, ok := v.(string); ok {
+					selector.MatchLabels[k] = s
+				}
 			}
 		}
 	}
@@ -324,20 +351,26 @@ func (w *Workload) GetSelector() (*metav1.LabelSelector, error) {
 
 func (w *Workload) GetAnnotation(annotation string) (string, bool) {
 	if v, ok := InspectWorkload(w.workload, "metadata", "annotations", annotation); ok {
-		return v.(string), ok
+		if s, ok := v.(string); ok {
+			return s, true
+		}
 	}
 	return "", false
 }
 func (w *Workload) GetLabel(label string) (string, bool) {
 	if v, ok := InspectWorkload(w.workload, "metadata", "labels", label); ok {
-		return v.(string), ok
+		if s, ok := v.(string); ok {
+			return s, true
+		}
 	}
 	return "", false
 }
 
 func (w *Workload) GetPodLabel(label string) (string, bool) {
 	if v, ok := InspectWorkload(w.workload, append(PodMetadata(w.GetKind()), "labels", label)...); ok && v != nil {
-		return v.(string), ok
+		if s, ok := v.(string); ok {
+			return s, true
+		}
 	}
 	return "", false
 }
@@ -398,7 +431,9 @@ func (w *Workload) GetInnerAnnotation(annotation string) (string, bool) {
 
 func (w *Workload) GetPodAnnotation(annotation string) (string, bool) {
 	if v, ok := InspectWorkload(w.workload, append(PodMetadata(w.GetKind()), "annotations", annotation)...); ok && v != nil {
-		return v.(string), ok
+		if s, ok := v.(string); ok {
+			return s, true
+		}
 	}
 	return "", false
 }
@@ -417,7 +452,9 @@ func (w *Workload) GetAnnotations() map[string]string {
 func (w *Workload) GetServiceAccountName() string {
 
 	if v, ok := InspectWorkload(w.workload, append(PodSpec(w.GetKind()), "serviceAccountName")...); ok && v != nil {
-		return v.(string)
+		if s, ok := v.(string); ok {
+			return s
+		}
 	}
 	return ""
 }
@@ -534,13 +571,23 @@ func (w *Workload) GetOwnerReferences() ([]metav1.OwnerReference, error) {
 }
 func (w *Workload) GetResourceVersion() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "resourceVersion"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }
 func (w *Workload) GetUID() string {
 	if v, ok := InspectWorkload(w.workload, "metadata", "uid"); ok {
-		return v.(string)
+
+		if s, ok := v.(string); ok {
+
+			return s
+
+		}
 	}
 	return ""
 }

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -607,3 +607,33 @@ func TestGetVolumes(t *testing.T) {
 	assert.Equal(t, 2, len(volumes))
 
 }
+
+func TestAccessorsWithNonStringMetadata(t *testing.T) {
+	// A manifest can be valid enough to be recognized as a workload and still
+	// carry a non-string value where a string is expected. The accessors used
+	// to assert the type outright and panic on such a document.
+	w, err := NewWorkload([]byte(`{
+		"apiVersion": "apps/v1",
+		"kind": "Deployment",
+		"metadata": {
+			"namespace": ["oops"],
+			"name": 42,
+			"labels": {"app": ["nope"]},
+			"annotations": {"note": 7}
+		}
+	}`))
+	assert.NoError(t, err)
+
+	assert.Equal(t, "", w.GetNamespace())
+	assert.Equal(t, "", w.GetName())
+	assert.NotPanics(t, func() { _ = w.GetID() })
+
+	_, ok := w.GetLabel("app")
+	assert.False(t, ok)
+	_, ok = w.GetAnnotation("note")
+	assert.False(t, ok)
+}
+
+func TestIsTypeListWorkloadsWithNonStringKind(t *testing.T) {
+	assert.False(t, IsTypeListWorkloads(map[string]interface{}{"kind": 123}))
+}

--- a/workloadinterface/workloadmethods_test.go
+++ b/workloadinterface/workloadmethods_test.go
@@ -613,25 +613,124 @@ func TestAccessorsWithNonStringMetadata(t *testing.T) {
 	// carry a non-string value where a string is expected. The accessors used
 	// to assert the type outright and panic on such a document.
 	w, err := NewWorkload([]byte(`{
-		"apiVersion": "apps/v1",
-		"kind": "Deployment",
+		"apiVersion": ["oops"],
+		"kind": 1,
 		"metadata": {
 			"namespace": ["oops"],
 			"name": 42,
+			"generateName": ["oops"],
+			"resourceVersion": 7,
+			"uid": ["oops"],
 			"labels": {"app": ["nope"]},
 			"annotations": {"note": 7}
+		},
+		"spec": {
+			"selector": {"matchLabels": {"app": ["nope"], "tier": "web"}},
+			"template": {
+				"metadata": {
+					"labels": {"app": ["nope"]},
+					"annotations": {"note": 7}
+				},
+				"spec": {"serviceAccountName": ["oops"]}
+			}
 		}
 	}`))
 	assert.NoError(t, err)
 
-	assert.Equal(t, "", w.GetNamespace())
-	assert.Equal(t, "", w.GetName())
+	for _, tc := range []struct {
+		name string
+		got  func(*Workload) string
+	}{
+		{"GetNamespace", (*Workload).GetNamespace},
+		{"GetName", (*Workload).GetName},
+		{"GetApiVersion", (*Workload).GetApiVersion},
+		{"GetKind", (*Workload).GetKind},
+		{"GetGenerateName", (*Workload).GetGenerateName},
+		{"GetResourceVersion", (*Workload).GetResourceVersion},
+		{"GetUID", (*Workload).GetUID},
+		{"GetServiceAccountName", (*Workload).GetServiceAccountName},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, "", tc.got(w))
+		})
+	}
+
 	assert.NotPanics(t, func() { _ = w.GetID() })
 
 	_, ok := w.GetLabel("app")
 	assert.False(t, ok)
 	_, ok = w.GetAnnotation("note")
 	assert.False(t, ok)
+	_, ok = w.GetPodLabel("app")
+	assert.False(t, ok)
+	_, ok = w.GetPodAnnotation("note")
+	assert.False(t, ok)
+
+	// the plural accessors read the same fields
+	assert.Equal(t, map[string]string{}, w.GetLabels())
+	assert.Equal(t, map[string]string{}, w.GetPodLabels())
+	assert.Equal(t, map[string]string{"note": "7"}, w.GetAnnotations())
+	assert.Equal(t, map[string]string{"note": "7"}, w.GetPodAnnotations())
+
+	// a mixed matchLabels keeps the string entry and drops the rest
+	selector, err := w.GetSelector()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"tier": "web"}, selector.MatchLabels)
+}
+
+// TestContainersWithNonMapValues covers the case where the container itself is
+// not a map, rather than one of its values.
+func TestContainersWithNonMapValues(t *testing.T) {
+	w, err := NewWorkload([]byte(`{
+		"apiVersion": "apps/v1",
+		"kind": "Deployment",
+		"metadata": {"name": "x", "labels": ["oops"], "annotations": "oops"},
+		"data": "oops",
+		"spec": {
+			"selector": ["oops"],
+			"template": {"metadata": {"labels": "oops", "annotations": ["oops"]}}
+		}
+	}`))
+	assert.NoError(t, err)
+
+	assert.Nil(t, w.GetLabels())
+	assert.Nil(t, w.GetAnnotations())
+	assert.Nil(t, w.GetPodLabels())
+	assert.Nil(t, w.GetPodAnnotations())
+	assert.Nil(t, w.GetData())
+	assert.Nil(t, w.GetServiceSelector())
+}
+
+// TestSettersWithNonMapNode covers the write path: SetInMap used to test only
+// for presence, so an existing non-map node left it writing into a nil map.
+func TestSettersWithNonMapNode(t *testing.T) {
+	w, err := NewWorkload([]byte(`{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": "oops"
+	}`))
+	assert.NoError(t, err)
+
+	assert.NotPanics(t, func() { w.SetNamespace("default") })
+	assert.Equal(t, "default", w.GetNamespace())
+
+	assert.NotPanics(t, func() { w.SetLabel("app", "web") })
+	label, ok := w.GetLabel("app")
+	assert.True(t, ok)
+	assert.Equal(t, "web", label)
+
+	// an existing, valid map must not be replaced
+	w2, err := NewWorkload([]byte(`{
+		"apiVersion": "v1",
+		"kind": "Pod",
+		"metadata": {"name": "keep-me"}
+	}`))
+	assert.NoError(t, err)
+	w2.SetNamespace("default")
+	assert.Equal(t, "keep-me", w2.GetName())
+	assert.Equal(t, "default", w2.GetNamespace())
+
+	assert.NotPanics(t, func() { w.RemoveLabel("app") })
 }
 
 func TestIsTypeListWorkloadsWithNonStringKind(t *testing.T) {


### PR DESCRIPTION
The accessors in `workloadinterface` check that a field is present and then assert it to `string` without a second return value:

```go
func (w *Workload) GetNamespace() string {
	if v, ok := InspectWorkload(w.workload, "metadata", "namespace"); ok {
		return v.(string)
	}
	return ""
}
```

The `ok` there only says the key exists, so a document that carries a non-string value panics:

```
panic: interface conversion: interface {} is []interface {}, not string
```

A manifest can reach that state and still look like a workload. `IsTypeWorkload` type-checks `apiVersion` and `kind` with comma-ok but never looks at `metadata.name` or `metadata.namespace`, so a Deployment with `namespace: [oops]` is accepted as a workload, and the panic then happens in `GetID`, which is called on every loaded object.

This switches the string reads to comma-ok and falls back to the empty string the functions already return when the field is missing:

- `GetNamespace`, `GetName`, `GetApiVersion`, `GetKind` and the equivalents on `BaseObject` and `ListWorkloads`
- `GetLabel`, `GetAnnotation`, `GetPodLabel`, which return `(string, bool)` and now report false rather than panicking
- `GetServiceAccountName`
- the `matchLabels` loop in `GetSelector`, which asserted each value
- the `kind` comparison in `IsTypeListWorkloads`

Related: I opened kubescape/kubescape#2604 yesterday, which adds a `recover` to `readJsonFile` so one bad file does not abort a scan. That is the containment; this is the source of the panic it was containing. They are independent, and this one also helps callers that never go through that path.

Tests: `TestAccessorsWithNonStringMetadata` builds a workload with a list namespace, a numeric name, and non-string label and annotation values, then asserts the accessors return empty and `GetID` does not panic. `TestIsTypeListWorkloadsWithNonStringKind` covers the comparison. Both panic on master.

`go test ./workloadinterface/` is green. `cloudsupport/v1` fails here for me both with and without this change (the EKS region and context-name tests), so that looks environmental rather than related.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload metadata and configuration accessors to safely handle invalid or non-string values.
  * Prevented errors when reading namespaces, names, API versions, kinds, labels, annotations, selectors, and related fields.
  * Ensured list-workload detection safely rejects invalid kind values.
  * Safely replaces malformed nested metadata when updating workload configuration.

* **Tests**
  * Added regression coverage for malformed workload metadata, annotation values, selectors, and nested configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->