### PR TITLE
fix(k8sinterface): refresh API discovery for a newly initialized live client

### DIFF
--- a/k8sinterface/k8sdiscovery.go
+++ b/k8sinterface/k8sdiscovery.go
@@ -117,14 +117,10 @@ func GetResourceNamesapcedScope() []string {
 // InitializeMapResources get supported api-resource (similar to 'kubectl api-resources') and map to 'ResourceGroupMapping' and 'ResourceNamesapcedScope'. If this function is not called, many functions may not work
 func InitializeMapResources(discoveryClient discovery.DiscoveryInterface) {
 
-	// load discovery data only if the map is empty
-	resourcesInfoLock.RLock()
-	resNsScopeLen := len(resourceNamesapcedScope)
-	resourcesInfoLock.RUnlock()
-	if resNsScopeLen != 0 {
-		return
-	}
-
+	// An explicitly supplied discovery client is authoritative: it belongs to a
+	// live cluster the caller has just initialized, so its discovery replaces
+	// whatever is cached. Otherwise a client built for a second cluster keeps
+	// resolving resources through the first cluster's snapshot.
 	if discoveryClient != nil {
 		resourceList, _ := discoveryClient.ServerPreferredResources()
 		if len(resourceList) != 0 {
@@ -133,11 +129,28 @@ func InitializeMapResources(discoveryClient discovery.DiscoveryInterface) {
 		}
 	}
 
+	// No usable client: keep the existing lazy behaviour and only populate when
+	// nothing has been loaded yet.
+	resourcesInfoLock.RLock()
+	resNsScopeLen := len(resourceNamesapcedScope)
+	resourcesInfoLock.RUnlock()
+	if resNsScopeLen != 0 {
+		return
+	}
+
 	// Fallback - load from mock
 	InitializeMapResourcesMock()
 
 }
+
+// setMapResources builds a fresh snapshot from resourceList and swaps it in, so
+// the globals describe exactly one cluster. Accumulating across calls would
+// produce a resource set that exists in neither cluster.
 func setMapResources(resourceList []*metav1.APIResourceList) {
+	newGroupMapping := map[string][]string{}
+	newNamespacedScope := []string{}
+	newClusterScope := []string{}
+
 	for i := range resourceList {
 		if resourceList[i] == nil {
 			continue
@@ -163,12 +176,11 @@ func setMapResources(resourceList []*metav1.APIResourceList) {
 
 			gvStr := JoinGroupVersion(gv.Group, gv.Version)
 
-			resourcesInfoLock.Lock()
 			// Append the group/version, deduping in case discovery returns the same
 			// (resource, group, version) tuple twice. Multiple groups serving the same
 			// resource name (e.g. "ingresses" in networking.k8s.io and extensions) are
 			// all preserved in insertion order.
-			existing := resourceGroupMapping[apiResource.Name]
+			existing := newGroupMapping[apiResource.Name]
 			alreadyPresent := false
 			for _, e := range existing {
 				if e == gvStr {
@@ -177,17 +189,23 @@ func setMapResources(resourceList []*metav1.APIResourceList) {
 				}
 			}
 			if !alreadyPresent {
-				resourceGroupMapping[apiResource.Name] = append(existing, gvStr)
+				newGroupMapping[apiResource.Name] = append(existing, gvStr)
 			}
 			if apiResource.Namespaced {
-				resourceNamesapcedScope = append(resourceNamesapcedScope, JoinResourceTriplets(gv.Group, gv.Version, apiResource.Name))
+				newNamespacedScope = append(newNamespacedScope, JoinResourceTriplets(gv.Group, gv.Version, apiResource.Name))
 			} else { // DEPRECATED
-				ResourceClusterScope = append(ResourceClusterScope, JoinResourceTriplets(gv.Group, gv.Version, apiResource.Name))
-
+				newClusterScope = append(newClusterScope, JoinResourceTriplets(gv.Group, gv.Version, apiResource.Name))
 			}
-			resourcesInfoLock.Unlock()
 		}
 	}
+
+	// Swap the whole snapshot in one critical section so readers never observe a
+	// partially rebuilt state.
+	resourcesInfoLock.Lock()
+	defer resourcesInfoLock.Unlock()
+	resourceGroupMapping = newGroupMapping
+	resourceNamesapcedScope = newNamespacedScope
+	ResourceClusterScope = newClusterScope
 }
 
 // IsKindKubernetes check if the kind is known to be a kubernetes kind. In this check we do not test the apiVersion

--- a/k8sinterface/k8sdiscovery_switch_test.go
+++ b/k8sinterface/k8sdiscovery_switch_test.go
@@ -1,0 +1,112 @@
+package k8sinterface
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+)
+
+// stubDiscovery serves a canned resource list. Only ServerPreferredResources is
+// exercised by InitializeMapResources, so the rest of the interface is left
+// embedded and unimplemented.
+type stubDiscovery struct {
+	discovery.DiscoveryInterface
+	resources []*metav1.APIResourceList
+}
+
+func (s *stubDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return s.resources, nil
+}
+
+func clusterDiscovery(crdName string) *stubDiscovery {
+	return &stubDiscovery{resources: []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Verbs: metav1.Verbs{"list"}},
+			},
+		},
+		{
+			GroupVersion: "example.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: crdName, Namespaced: true, Verbs: metav1.Verbs{"list"}},
+			},
+		},
+	}}
+}
+
+// resetDiscoveryState clears the process-global discovery snapshot so each test
+// starts from the same place.
+func resetDiscoveryState(t *testing.T) {
+	t.Helper()
+	resourcesInfoLock.Lock()
+	defer resourcesInfoLock.Unlock()
+	resourceGroupMapping = map[string][]string{}
+	resourceNamesapcedScope = []string{}
+	ResourceClusterScope = []string{}
+}
+
+func hasResource(name string) bool {
+	resourcesInfoLock.RLock()
+	defer resourcesInfoLock.RUnlock()
+	_, ok := resourceGroupMapping[name]
+	return ok
+}
+
+func namespacedScopeHas(triplet string) bool {
+	resourcesInfoLock.RLock()
+	defer resourcesInfoLock.RUnlock()
+	for _, r := range resourceNamesapcedScope {
+		if r == triplet {
+			return true
+		}
+	}
+	return false
+}
+
+// A second live client, built for a different cluster, must not keep serving the
+// first cluster's API discovery. InitializeMapResources returns early whenever
+// the global snapshot is already populated, so today cluster B inherits A's.
+func TestInitializeMapResources_ReplacesDiscoveryForSecondLiveClient(t *testing.T) {
+	resetDiscoveryState(t)
+	t.Cleanup(func() { resetDiscoveryState(t) })
+
+	InitializeMapResources(clusterDiscovery("foos"))
+
+	require.True(t, hasResource("foos"), "cluster A discovery should be loaded")
+	require.False(t, hasResource("bars"), "cluster B CRD must not be present yet")
+
+	// Switch to a client for a different cluster.
+	InitializeMapResources(clusterDiscovery("bars"))
+
+	assert.True(t, hasResource("bars"), "cluster B CRD must be discoverable after switching")
+	assert.False(t, hasResource("foos"), "cluster A CRD must not survive the switch")
+}
+
+// The namespaced-scope slice has the same problem, and because setMapResources
+// appends rather than replaces, a naive fix would leave a union of both clusters.
+func TestInitializeMapResources_ReplacesNamespacedScopeForSecondLiveClient(t *testing.T) {
+	resetDiscoveryState(t)
+	t.Cleanup(func() { resetDiscoveryState(t) })
+
+	InitializeMapResources(clusterDiscovery("foos"))
+	require.True(t, namespacedScopeHas("example.io/v1/foos"))
+
+	InitializeMapResources(clusterDiscovery("bars"))
+
+	assert.True(t, namespacedScopeHas("example.io/v1/bars"), "cluster B resource must be namespaced-scoped")
+	assert.False(t, namespacedScopeHas("example.io/v1/foos"), "cluster A resource must not survive the switch")
+}
+
+// Passing nil must keep the existing lazy/mock fallback behaviour.
+func TestInitializeMapResources_NilClientStillFallsBackToMock(t *testing.T) {
+	resetDiscoveryState(t)
+	t.Cleanup(func() { resetDiscoveryState(t) })
+
+	InitializeMapResources(nil)
+
+	assert.True(t, hasResource("pods"), "the mock fallback should still populate discovery")
+}


### PR DESCRIPTION
## Overview

`InitializeMapResources` loads API discovery once per process and then refuses
to reload it:

```go
resourcesInfoLock.RLock()
resNsScopeLen := len(resourceNamesapcedScope)
resourcesInfoLock.RUnlock()
if resNsScopeLen != 0 {
	return
}
```

`NewKubernetesApi()` calls it with a real discovery client for the cluster it is
building (`k8sconfig.go:75`), so the second cluster's discovery is discarded and
that client keeps resolving resources through the first cluster's
`resourceGroupMapping` and `resourceNamesapcedScope`. CRDs present in one
cluster and not the other are the clearest case, but it also affects
namespaced vs cluster-scoped classification and which GVRs are queryable.

This makes an explicitly supplied discovery client authoritative: it belongs to
a live cluster the caller has just initialized, so its discovery replaces what
is cached. `InitializeMapResources(nil)` keeps the existing lazy/mock fallback
untouched.

**`setMapResources` now replaces instead of appending.** It previously did:

```go
resourceGroupMapping[apiResource.Name] = append(existing, gvStr)
resourceNamesapcedScope = append(resourceNamesapcedScope, ...)
```

so simply dropping the early return would have produced a union of both
clusters — a resource set belonging to neither. It now builds the maps locally
and swaps them in. That also fixes incidental locking: the old version took and
released the lock once per resource, so a reader could observe a half-rebuilt
snapshot. The swap is now a single critical section.

## How to Test

```bash
go test ./k8sinterface/ -run TestInitializeMapResources_ -count=1
```

Three tests, using two stub discovery clients that share `v1/pods` but differ in
their `example.io/v1` CRD (`foos` in cluster A, `bars` in cluster B):

| Test | Asserts |
|---|---|
| `ReplacesDiscoveryForSecondLiveClient` | after switching to B, `bars` is discoverable and `foos` is gone |
| `ReplacesNamespacedScopeForSecondLiveClient` | same for `resourceNamesapcedScope` |
| `NilClientStillFallsBackToMock` | `InitializeMapResources(nil)` behaviour is unchanged |

The first two fail on master:

```
--- FAIL: TestInitializeMapResources_ReplacesDiscoveryForSecondLiveClient
    Error: Should be true      // hasResource("bars")
    Error: Should be false     // hasResource("foos")
```

Also ran:

```bash
go build ./...
go vet ./k8sinterface/
go test ./... -count=1                                                  # all green
go test -race ./k8sinterface/ -run TestInitializeMapResources_ -count=5
```

## Related issues/PRs

Closes #159

Related to #158, which covers `SetClusterContextName` not re-pointing
`K8SConfig`/`clientConfigAPI`. That is a different global with a different root
cause; as @shreyashsri79 confirmed there, the discovery layer has no caller-side
workaround at all because `resourceGroupMapping`/`resourceNamesapcedScope` are
unexported and never reset. The two are complementary rather than overlapping.
